### PR TITLE
Add AWS SSO / Identity Center + Bedrock auth for Agentic Coding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,5 +90,10 @@ let package = Package(
             dependencies: ["SandboxEngine", "BrowserBridges"],
             path: "Tests/SafariSandboxTests"
         ),
+        .testTarget(
+            name: "AgentCodingTests",
+            dependencies: ["bromure-ac"],
+            path: "Tests/AgentCodingTests"
+        ),
     ]
 )

--- a/Sources/AgentCoding/AWSConfigParser.swift
+++ b/Sources/AgentCoding/AWSConfigParser.swift
@@ -7,6 +7,7 @@ public struct DiscoveredSSOProfile: Identifiable, Hashable, Sendable {
     public let ssoRoleName: String
     public let ssoRegion: String
     public let region: String
+    public let ssoSessionName: String?
     public var id: String { name }
 }
 
@@ -128,7 +129,8 @@ public enum AWSConfigParser {
             ssoAccountID: accountID,
             ssoRoleName: roleName,
             ssoRegion: ssoRegion,
-            region: region
+            region: region,
+            ssoSessionName: fields["sso_session"]
         )
     }
 }

--- a/Sources/AgentCoding/AWSConfigParser.swift
+++ b/Sources/AgentCoding/AWSConfigParser.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+public struct DiscoveredSSOProfile: Identifiable, Hashable, Sendable {
+    public let name: String
+    public let ssoStartURL: String
+    public let ssoAccountID: String
+    public let ssoRoleName: String
+    public let ssoRegion: String
+    public let region: String
+    public var id: String { name }
+}
+
+public enum AWSConfigParser {
+
+    public static func discover(configPath: String? = nil) -> [DiscoveredSSOProfile] {
+        let path = configPath ?? defaultConfigPath()
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return []
+        }
+        let (profiles, ssoSessions) = parseSections(contents)
+        return profiles.compactMap { resolveProfile($0, ssoSessions: ssoSessions) }
+    }
+
+    // MARK: - Private
+
+    private static func defaultConfigPath() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.aws/config"
+    }
+
+    private struct RawSection {
+        var name: String
+        var fields: [String: String] = [:]
+    }
+
+    private static func parseSections(_ text: String) -> (profiles: [RawSection], ssoSessions: [String: RawSection]) {
+        var profiles: [RawSection] = []
+        var ssoSessions: [String: RawSection] = [:]
+        var current: RawSection?
+        var currentKind: String?
+
+        for line in text.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") || trimmed.hasPrefix(";") {
+                continue
+            }
+
+            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+                if let section = current {
+                    storeSection(section, kind: currentKind, profiles: &profiles, ssoSessions: &ssoSessions)
+                }
+                let header = trimmed.dropFirst().dropLast()
+                    .trimmingCharacters(in: .whitespaces)
+
+                if header.hasPrefix("profile ") {
+                    let name = String(header.dropFirst("profile ".count))
+                        .trimmingCharacters(in: .whitespaces)
+                    current = RawSection(name: name)
+                    currentKind = "profile"
+                } else if header.hasPrefix("sso-session ") {
+                    let name = String(header.dropFirst("sso-session ".count))
+                        .trimmingCharacters(in: .whitespaces)
+                    current = RawSection(name: name)
+                    currentKind = "sso-session"
+                } else if header == "default" {
+                    current = RawSection(name: "default")
+                    currentKind = "profile"
+                } else {
+                    current = nil
+                    currentKind = nil
+                }
+                continue
+            }
+
+            guard current != nil else { continue }
+            if let eqIdx = trimmed.firstIndex(of: "=") {
+                let key = trimmed[trimmed.startIndex..<eqIdx]
+                    .trimmingCharacters(in: .whitespaces)
+                let value = trimmed[trimmed.index(after: eqIdx)...]
+                    .trimmingCharacters(in: .whitespaces)
+                current!.fields[key] = value
+            }
+        }
+        if let section = current {
+            storeSection(section, kind: currentKind, profiles: &profiles, ssoSessions: &ssoSessions)
+        }
+        return (profiles, ssoSessions)
+    }
+
+    private static func storeSection(
+        _ section: RawSection,
+        kind: String?,
+        profiles: inout [RawSection],
+        ssoSessions: inout [String: RawSection]
+    ) {
+        switch kind {
+        case "profile":     profiles.append(section)
+        case "sso-session": ssoSessions[section.name] = section
+        default:            break
+        }
+    }
+
+    private static func resolveProfile(
+        _ section: RawSection,
+        ssoSessions: [String: RawSection]
+    ) -> DiscoveredSSOProfile? {
+        var fields = section.fields
+
+        if let sessionName = fields["sso_session"],
+           let session = ssoSessions[sessionName] {
+            for (k, v) in session.fields where fields[k] == nil {
+                fields[k] = v
+            }
+        }
+
+        guard let startURL = fields["sso_start_url"],
+              let accountID = fields["sso_account_id"],
+              let roleName = fields["sso_role_name"] else {
+            return nil
+        }
+
+        let ssoRegion = fields["sso_region"] ?? fields["region"] ?? ""
+        let region = fields["region"] ?? ssoRegion
+
+        return DiscoveredSSOProfile(
+            name: section.name,
+            ssoStartURL: startURL,
+            ssoAccountID: accountID,
+            ssoRoleName: roleName,
+            ssoRegion: ssoRegion,
+            region: region
+        )
+    }
+}

--- a/Sources/AgentCoding/AWSSSOResolver.swift
+++ b/Sources/AgentCoding/AWSSSOResolver.swift
@@ -41,7 +41,7 @@ public enum AWSSSOResolver {
 
         let ssoRegion = profile.ssoRegion.isEmpty ? profile.region : profile.ssoRegion
 
-        if let cached = readCachedToken(startURL: profile.ssoStartURL) {
+        if let cached = readCachedToken(startURL: profile.ssoStartURL, ssoRegion: ssoRegion, sessionName: profile.ssoSessionName) {
             let creds = try await getRoleCredentials(
                 accessToken: cached,
                 accountID: profile.ssoAccountID,
@@ -64,7 +64,7 @@ public enum AWSSSOResolver {
         progress?("SSO login required — opening browser…")
         try await runSSOLogin(profileName: profileName)
 
-        guard let token = readCachedToken(startURL: profile.ssoStartURL) else {
+        guard let token = readCachedToken(startURL: profile.ssoStartURL, ssoRegion: ssoRegion, sessionName: profile.ssoSessionName) else {
             throw Error.tokenExpired
         }
 
@@ -114,31 +114,78 @@ public enum AWSSSOResolver {
 
     // MARK: - SSO Token Cache
 
-    private static func readCachedToken(startURL: String) -> String? {
+    private static func readCachedToken(startURL: String, ssoRegion: String, sessionName: String?) -> String? {
         let cacheDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".aws/sso/cache", isDirectory: true)
 
-        let hash = sha1Hex(startURL)
-        let cacheFile = cacheDir.appendingPathComponent("\(hash).json")
+        // Try direct hash lookup: SHA1("startUrl|region")
+        let sessionKey = "\(startURL)|\(ssoRegion)"
+        let hashFile = cacheDir.appendingPathComponent("\(sha1Hex(sessionKey)).json")
+        if let token = extractValidToken(from: hashFile) {
+            return token
+        }
 
-        guard let data = try? Data(contentsOf: cacheFile),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let accessToken = json["accessToken"] as? String,
-              let expiresAtString = json["expiresAt"] as? String else {
+        // Also try SHA1(startURL) for older CLIs
+        let legacyFile = cacheDir.appendingPathComponent("\(sha1Hex(startURL)).json")
+        if let token = extractValidToken(from: legacyFile) {
+            return token
+        }
+
+        // Fallback: scan all cache files for a match by content
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: cacheDir, includingPropertiesForKeys: nil) else {
             return nil
         }
 
+        for file in files where file.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: file),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let accessToken = json["accessToken"] as? String else {
+                continue
+            }
+
+            // Match by session name (sso-session profiles)
+            if let sessionName, let fileSession = json["sessionName"] as? String,
+               fileSession == sessionName {
+                if let token = extractValidToken(accessToken: accessToken,
+                                                  expiresAtString: json["expiresAt"] as? String) {
+                    return token
+                }
+            }
+
+            // Match by startUrl + region fields
+            if let storedURL = json["startUrl"] as? String,
+               let storedRegion = json["region"] as? String,
+               storedURL == startURL && storedRegion == ssoRegion {
+                if let token = extractValidToken(accessToken: accessToken,
+                                                  expiresAtString: json["expiresAt"] as? String) {
+                    return token
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private static func extractValidToken(from file: URL) -> String? {
+        guard let data = try? Data(contentsOf: file),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["accessToken"] as? String else {
+            return nil
+        }
+        return extractValidToken(accessToken: accessToken,
+                                  expiresAtString: json["expiresAt"] as? String)
+    }
+
+    private static func extractValidToken(accessToken: String, expiresAtString: String?) -> String? {
+        guard let expiresAtString else { return nil }
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         guard let expiresAt = formatter.date(from: expiresAtString)
                 ?? ISO8601DateFormatter().date(from: expiresAtString) else {
             return nil
         }
-
-        if expiresAt.timeIntervalSinceNow < 5 * 60 {
-            return nil
-        }
-
+        if expiresAt.timeIntervalSinceNow < 5 * 60 { return nil }
         return accessToken
     }
 

--- a/Sources/AgentCoding/AWSSSOResolver.swift
+++ b/Sources/AgentCoding/AWSSSOResolver.swift
@@ -1,0 +1,244 @@
+import CommonCrypto
+import Foundation
+
+public struct ResolvedAWSCredentials: Sendable {
+    public let accessKeyID: String
+    public let secretAccessKey: String
+    public let sessionToken: String
+    public let region: String
+    public let expiration: Date
+}
+
+public enum AWSSSOResolver {
+
+    public enum Error: Swift.Error, LocalizedError {
+        case noProfile(String)
+        case loginFailed(String)
+        case tokenExpired
+        case credentialFetchFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .noProfile(let name):      return "SSO profile '\(name)' not found in ~/.aws/config"
+            case .loginFailed(let reason):  return "AWS SSO login failed: \(reason)"
+            case .tokenExpired:             return "SSO token is expired and login was not completed"
+            case .credentialFetchFailed(let reason): return "Failed to get role credentials: \(reason)"
+            }
+        }
+    }
+
+    // MARK: - Public
+
+    public static func resolve(
+        profileName: String,
+        triggerLoginIfNeeded: Bool = true,
+        progress: ((String) -> Void)? = nil
+    ) async throws -> ResolvedAWSCredentials {
+        let profiles = AWSConfigParser.discover()
+        guard let profile = profiles.first(where: { $0.name == profileName }) else {
+            throw Error.noProfile(profileName)
+        }
+
+        let ssoRegion = profile.ssoRegion.isEmpty ? profile.region : profile.ssoRegion
+
+        if let cached = readCachedToken(startURL: profile.ssoStartURL) {
+            let creds = try await getRoleCredentials(
+                accessToken: cached,
+                accountID: profile.ssoAccountID,
+                roleName: profile.ssoRoleName,
+                ssoRegion: ssoRegion
+            )
+            return ResolvedAWSCredentials(
+                accessKeyID: creds.accessKeyID,
+                secretAccessKey: creds.secretAccessKey,
+                sessionToken: creds.sessionToken,
+                region: profile.region,
+                expiration: creds.expiration
+            )
+        }
+
+        guard triggerLoginIfNeeded else {
+            throw Error.tokenExpired
+        }
+
+        progress?("SSO login required — opening browser…")
+        try await runSSOLogin(profileName: profileName)
+
+        guard let token = readCachedToken(startURL: profile.ssoStartURL) else {
+            throw Error.tokenExpired
+        }
+
+        let creds = try await getRoleCredentials(
+            accessToken: token,
+            accountID: profile.ssoAccountID,
+            roleName: profile.ssoRoleName,
+            ssoRegion: ssoRegion
+        )
+        return ResolvedAWSCredentials(
+            accessKeyID: creds.accessKeyID,
+            secretAccessKey: creds.secretAccessKey,
+            sessionToken: creds.sessionToken,
+            region: profile.region,
+            expiration: creds.expiration
+        )
+    }
+
+    public static func startRefreshLoop(
+        profileName: String,
+        initialExpiration: Date,
+        onRefresh: @escaping (ResolvedAWSCredentials) -> Void,
+        onError: @escaping (Swift.Error) -> Void
+    ) -> Task<Void, Never> {
+        Task.detached(priority: .utility) {
+            var expiration = initialExpiration
+            while !Task.isCancelled {
+                let refreshAt = expiration.addingTimeInterval(-5 * 60)
+                let delay = max(refreshAt.timeIntervalSinceNow, 30)
+                try? await Task.sleep(for: .seconds(delay))
+                if Task.isCancelled { break }
+
+                do {
+                    let creds = try await resolve(
+                        profileName: profileName,
+                        triggerLoginIfNeeded: false
+                    )
+                    expiration = creds.expiration
+                    onRefresh(creds)
+                } catch {
+                    onError(error)
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - SSO Token Cache
+
+    private static func readCachedToken(startURL: String) -> String? {
+        let cacheDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".aws/sso/cache", isDirectory: true)
+
+        let hash = sha1Hex(startURL)
+        let cacheFile = cacheDir.appendingPathComponent("\(hash).json")
+
+        guard let data = try? Data(contentsOf: cacheFile),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["accessToken"] as? String,
+              let expiresAtString = json["expiresAt"] as? String else {
+            return nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let expiresAt = formatter.date(from: expiresAtString)
+                ?? ISO8601DateFormatter().date(from: expiresAtString) else {
+            return nil
+        }
+
+        if expiresAt.timeIntervalSinceNow < 5 * 60 {
+            return nil
+        }
+
+        return accessToken
+    }
+
+    private static func sha1Hex(_ string: String) -> String {
+        let data = Data(string.utf8)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes { ptr in
+            _ = CC_SHA1(ptr.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - SSO Login
+
+    private static func runSSOLogin(profileName: String) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Swift.Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/local/bin/aws")
+                process.arguments = ["sso", "login", "--profile", profileName]
+
+                let errPipe = Pipe()
+                process.standardError = errPipe
+                process.standardOutput = FileHandle.nullDevice
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    if process.terminationStatus == 0 {
+                        cont.resume()
+                    } else {
+                        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                        let errStr = String(data: errData, encoding: .utf8) ?? "exit \(process.terminationStatus)"
+                        cont.resume(throwing: Error.loginFailed(errStr.trimmingCharacters(in: .whitespacesAndNewlines)))
+                    }
+                } catch {
+                    cont.resume(throwing: Error.loginFailed(error.localizedDescription))
+                }
+            }
+        }
+    }
+
+    // MARK: - GetRoleCredentials
+
+    private struct RoleCredentials {
+        let accessKeyID: String
+        let secretAccessKey: String
+        let sessionToken: String
+        let expiration: Date
+    }
+
+    private static func getRoleCredentials(
+        accessToken: String,
+        accountID: String,
+        roleName: String,
+        ssoRegion: String
+    ) async throws -> RoleCredentials {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "portal.sso.\(ssoRegion).amazonaws.com"
+        components.path = "/federation/credentials"
+        components.queryItems = [
+            URLQueryItem(name: "role_name", value: roleName),
+            URLQueryItem(name: "account_id", value: accountID),
+        ]
+
+        guard let url = components.url else {
+            throw Error.credentialFetchFailed("invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(accessToken, forHTTPHeaderField: "x-amz-sso_bearer_token")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw Error.credentialFetchFailed("non-HTTP response")
+        }
+        guard http.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw Error.credentialFetchFailed("HTTP \(http.statusCode): \(body)")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let roleCreds = json["roleCredentials"] as? [String: Any],
+              let akid = roleCreds["accessKeyId"] as? String,
+              let secret = roleCreds["secretAccessKey"] as? String,
+              let token = roleCreds["sessionToken"] as? String,
+              let expirationMs = roleCreds["expiration"] as? Int64 else {
+            throw Error.credentialFetchFailed("unexpected response format")
+        }
+
+        let expiration = Date(timeIntervalSince1970: Double(expirationMs) / 1000.0)
+
+        return RoleCredentials(
+            accessKeyID: akid,
+            secretAccessKey: secret,
+            sessionToken: token,
+            expiration: expiration
+        )
+    }
+}

--- a/Sources/AgentCoding/BromureAC.swift
+++ b/Sources/AgentCoding/BromureAC.swift
@@ -263,6 +263,7 @@ final class ACAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// otherwise the Task keeps pushing model updates after the window
     /// is gone and the autorelease pool over-releases on the next tick.
     private var installTask: Task<Void, Never>?
+    private var ssoRefreshTasks: [UUID: Task<Void, Never>] = [:]
 
     /// Process-lifetime MITM engine. One instance per app run, holds
     /// the CA + per-profile token swap maps + ssh-agent keystore. Lazy
@@ -669,6 +670,8 @@ final class ACAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             for key in loadAgentKeys(for: session.profile) {
                 removeKeyFromHostAgent(publicKey: key.publicKey)
             }
+            ssoRefreshTasks[session.profile.id]?.cancel()
+            ssoRefreshTasks.removeValue(forKey: session.profile.id)
             mitmEngine?.clearSessionTrace(for: session.profile.id)
             mitmEngine?.unregister(profileID: session.profile.id)
             profileWindows.removeValue(forKey: session.profile.id)
@@ -1388,7 +1391,55 @@ final class ACAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             // re-signs each AWS request with the real material so the
             // secret never lives in the VM at all. setCredentials clears
             // the slot when the profile has no usable AWS creds.
-            engine.awsCreds.setCredentials(profile.awsCredentials, for: profile.id)
+            if profile.awsCredentials.authMode == .ssoProfile
+                || profile.authMode == .bedrock {
+                let profileID = profile.id
+                let ssoProfileName = profile.awsCredentials.ssoProfileName
+                let awsCreds = profile.awsCredentials
+                FileHandle.standardError.write(Data(
+                    "[sso] resolving credentials for SSO profile '\(ssoProfileName)'\n".utf8))
+                Task { [weak engine, weak self] in
+                    guard let engine else { return }
+                    do {
+                        let resolved = try await AWSSSOResolver.resolve(
+                            profileName: ssoProfileName,
+                            progress: { msg in
+                                FileHandle.standardError.write(Data("[sso] \(msg)\n".utf8))
+                            }
+                        )
+                        var creds = awsCreds
+                        creds.accessKeyID = resolved.accessKeyID
+                        creds.secretAccessKey = resolved.secretAccessKey
+                        creds.sessionToken = resolved.sessionToken
+                        if creds.region.isEmpty { creds.region = resolved.region }
+                        engine.awsCreds.setCredentials(creds, for: profileID)
+
+                        self?.ssoRefreshTasks[profileID] = AWSSSOResolver.startRefreshLoop(
+                            profileName: ssoProfileName,
+                            initialExpiration: resolved.expiration,
+                            onRefresh: { [weak engine] newCreds in
+                                var updated = awsCreds
+                                updated.accessKeyID = newCreds.accessKeyID
+                                updated.secretAccessKey = newCreds.secretAccessKey
+                                updated.sessionToken = newCreds.sessionToken
+                                engine?.awsCreds.setCredentials(updated, for: profileID)
+                                FileHandle.standardError.write(Data(
+                                    "[sso] refreshed credentials for '\(ssoProfileName)'\n".utf8))
+                            },
+                            onError: { error in
+                                FileHandle.standardError.write(Data(
+                                    "[sso] refresh failed: \(error.localizedDescription)\n".utf8))
+                            }
+                        )
+                    } catch {
+                        FileHandle.standardError.write(Data(
+                            "[sso] credential resolution failed: \(error.localizedDescription)\n".utf8))
+                        engine.awsCreds.setCredentials(awsCreds, for: profileID)
+                    }
+                }
+            } else {
+                engine.awsCreds.setCredentials(profile.awsCredentials, for: profile.id)
+            }
             FileHandle.standardError.write(Data(
                 "[mitm] session launch for '\(profile.name)': loaded \(agentKeys.count) agent key(s)\n".utf8))
             // Mirror the per-profile key into our private bromure

--- a/Sources/AgentCoding/Profile.swift
+++ b/Sources/AgentCoding/Profile.swift
@@ -393,7 +393,15 @@ public struct DockerRegistryCredential: Codable, Equatable, Sendable, Identifiab
 /// signature, and recomputes SigV4 with the real material that never
 /// enters the VM's address space. If the proxy is bypassed, AWS
 /// rejects with `InvalidSignatureException` — fail-closed.
+
+public enum AWSAuthMode: String, Codable, CaseIterable, Sendable {
+    case staticKeys
+    case ssoProfile
+}
+
 public struct AWSCredentials: Codable, Equatable, Sendable {
+    /// How the credentials are sourced: static IAM keys or SSO profile.
+    public var authMode: AWSAuthMode
     /// e.g. `AKIAIOSFODNN7EXAMPLE`. Identity-only on the wire.
     public var accessKeyID: String
     /// Secret signing key. Stored encrypted in the secrets vault.
@@ -409,43 +417,71 @@ public struct AWSCredentials: Codable, Equatable, Sendable {
     /// grant covers the request. See `ConsentBroker`.
     public var requireApproval: Bool
 
+    /// The `[profile <name>]` from `~/.aws/config` when `authMode == .ssoProfile`.
+    public var ssoProfileName: String
+    /// Read-only, populated from config discovery.
+    public var ssoAccountId: String
+    /// Read-only, populated from config discovery.
+    public var ssoRoleName: String
+
     public init(accessKeyID: String = "",
                 secretAccessKey: String = "",
                 sessionToken: String = "",
                 region: String = "",
-                requireApproval: Bool = false) {
+                requireApproval: Bool = false,
+                authMode: AWSAuthMode = .staticKeys,
+                ssoProfileName: String = "",
+                ssoAccountId: String = "",
+                ssoRoleName: String = "") {
+        self.authMode = authMode
         self.accessKeyID = accessKeyID
         self.secretAccessKey = secretAccessKey
         self.sessionToken = sessionToken
         self.region = region
         self.requireApproval = requireApproval
+        self.ssoProfileName = ssoProfileName
+        self.ssoAccountId = ssoAccountId
+        self.ssoRoleName = ssoRoleName
     }
 
-    /// True when at least the access-key + secret pair is set — the
-    /// minimum for a signing-capable profile.
+    /// True when credentials are configured enough to attempt signing.
     public var isUsable: Bool {
-        !accessKeyID.trimmingCharacters(in: .whitespaces).isEmpty
-            && !secretAccessKey.isEmpty
+        switch authMode {
+        case .staticKeys:
+            return !accessKeyID.trimmingCharacters(in: .whitespaces).isEmpty
+                && !secretAccessKey.isEmpty
+        case .ssoProfile:
+            return !ssoProfileName.trimmingCharacters(in: .whitespaces).isEmpty
+        }
     }
 
     private enum CodingKeys: String, CodingKey {
-        case accessKeyID, secretAccessKey, sessionToken, region, requireApproval
+        case authMode, accessKeyID, secretAccessKey, sessionToken, region
+        case requireApproval, ssoProfileName, ssoAccountId, ssoRoleName
     }
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        authMode        = try c.decodeIfPresent(AWSAuthMode.self, forKey: .authMode) ?? .staticKeys
         accessKeyID     = try c.decodeIfPresent(String.self, forKey: .accessKeyID) ?? ""
         secretAccessKey = try c.decodeIfPresent(String.self, forKey: .secretAccessKey) ?? ""
         sessionToken    = try c.decodeIfPresent(String.self, forKey: .sessionToken) ?? ""
         region          = try c.decodeIfPresent(String.self, forKey: .region) ?? ""
         requireApproval = try c.decodeIfPresent(Bool.self, forKey: .requireApproval) ?? false
+        ssoProfileName  = try c.decodeIfPresent(String.self, forKey: .ssoProfileName) ?? ""
+        ssoAccountId    = try c.decodeIfPresent(String.self, forKey: .ssoAccountId) ?? ""
+        ssoRoleName     = try c.decodeIfPresent(String.self, forKey: .ssoRoleName) ?? ""
     }
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
+        if authMode != .staticKeys { try c.encode(authMode, forKey: .authMode) }
         try c.encode(accessKeyID, forKey: .accessKeyID)
         try c.encode(secretAccessKey, forKey: .secretAccessKey)
         try c.encode(sessionToken, forKey: .sessionToken)
         try c.encode(region, forKey: .region)
         if requireApproval { try c.encode(true, forKey: .requireApproval) }
+        if !ssoProfileName.isEmpty { try c.encode(ssoProfileName, forKey: .ssoProfileName) }
+        if !ssoAccountId.isEmpty { try c.encode(ssoAccountId, forKey: .ssoAccountId) }
+        if !ssoRoleName.isEmpty { try c.encode(ssoRoleName, forKey: .ssoRoleName) }
     }
 }
 
@@ -515,11 +551,13 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
     public enum AuthMode: String, Codable, CaseIterable, Sendable {
         case token         // user-supplied API key, injected as env var
         case subscription  // user runs `claude login` / `codex login` in the VM
+        case bedrock       // AWS Bedrock via SSO or static IAM keys
 
         public var displayName: String {
             switch self {
             case .token:        return "API token"
             case .subscription: return "Subscription (interactive login)"
+            case .bedrock:      return "Bedrock (AWS)"
             }
         }
     }
@@ -636,6 +674,15 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
     /// for the AWS CLI / SDKs. See `AWSCredentials` for the SigV4
     /// reasoning. Empty struct (`isUsable == false`) = not configured.
     public var awsCredentials: AWSCredentials
+
+    /// When true and the Claude tool is configured, write Bedrock env
+    /// vars into `~/.claude/settings.json` so Claude Code uses the AWS
+    /// credential chain instead of an Anthropic API key.
+    public var bedrockEnabled: Bool
+
+    /// Bedrock model ID, e.g. `us.anthropic.claude-sonnet-4-6-v1:0`.
+    /// Empty string uses Claude Code's default.
+    public var bedrockModelID: String
 
     /// Container-registry credentials. One entry per host. Materialized
     /// as ~/.docker/config.json `auths` entries (with FAKE base64 auth
@@ -797,6 +844,8 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
         kubeconfigs: [KubeconfigEntry] = [],
         digitalOceanToken: String = "",
         awsCredentials: AWSCredentials = AWSCredentials(),
+        bedrockEnabled: Bool = false,
+        bedrockModelID: String = "",
         dockerRegistries: [DockerRegistryCredential] = [],
         apiKeyRequiresApproval: Bool = false,
         digitalOceanTokenRequiresApproval: Bool = false,
@@ -839,6 +888,8 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
         self.kubeconfigs = kubeconfigs
         self.digitalOceanToken = digitalOceanToken
         self.awsCredentials = awsCredentials
+        self.bedrockEnabled = bedrockEnabled
+        self.bedrockModelID = bedrockModelID
         self.dockerRegistries = dockerRegistries
         self.apiKeyRequiresApproval = apiKeyRequiresApproval
         self.digitalOceanTokenRequiresApproval = digitalOceanTokenRequiresApproval
@@ -887,6 +938,7 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
         case kubeconfigs
         case digitalOceanToken
         case awsCredentials
+        case bedrockEnabled, bedrockModelID
         case dockerRegistries
         case apiKeyRequiresApproval
         case digitalOceanTokenRequiresApproval
@@ -954,6 +1006,8 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
         kubeconfigs = try c.decodeIfPresent([KubeconfigEntry].self, forKey: .kubeconfigs) ?? []
         digitalOceanToken = try c.decodeIfPresent(String.self, forKey: .digitalOceanToken) ?? ""
         awsCredentials = try c.decodeIfPresent(AWSCredentials.self, forKey: .awsCredentials) ?? AWSCredentials()
+        bedrockEnabled = try c.decodeIfPresent(Bool.self, forKey: .bedrockEnabled) ?? false
+        bedrockModelID = try c.decodeIfPresent(String.self, forKey: .bedrockModelID) ?? ""
         dockerRegistries = try c.decodeIfPresent([DockerRegistryCredential].self, forKey: .dockerRegistries) ?? []
         apiKeyRequiresApproval = try c.decodeIfPresent(Bool.self, forKey: .apiKeyRequiresApproval) ?? false
         digitalOceanTokenRequiresApproval = try c.decodeIfPresent(Bool.self, forKey: .digitalOceanTokenRequiresApproval) ?? false
@@ -1018,9 +1072,12 @@ public struct Profile: Codable, Identifiable, Equatable, Sendable {
         }
         if awsCredentials.isUsable
             || !awsCredentials.region.isEmpty
-            || !awsCredentials.accessKeyID.isEmpty {
+            || !awsCredentials.accessKeyID.isEmpty
+            || awsCredentials.authMode != .staticKeys {
             try c.encode(awsCredentials, forKey: .awsCredentials)
         }
+        if bedrockEnabled { try c.encode(true, forKey: .bedrockEnabled) }
+        if !bedrockModelID.isEmpty { try c.encode(bedrockModelID, forKey: .bedrockModelID) }
         if !dockerRegistries.isEmpty {
             try c.encode(dockerRegistries, forKey: .dockerRegistries)
         }

--- a/Sources/AgentCoding/Profile.swift
+++ b/Sources/AgentCoding/Profile.swift
@@ -1949,6 +1949,38 @@ public final class ProfileStore {
             try? fm.removeItem(at: awsConfigURL)
         }
 
+        // ~/.claude/settings.json — Bedrock configuration for Claude Code.
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        let claudeSettingsURL = claudeDir.appendingPathComponent("settings.json")
+        if profile.bedrockEnabled {
+            try fm.createDirectory(at: claudeDir, withIntermediateDirectories: true,
+                                   attributes: [.posixPermissions: NSNumber(value: 0o700)])
+            var env: [String: String] = [
+                "CLAUDE_CODE_USE_BEDROCK": "1",
+                "AWS_PROFILE": "default",
+            ]
+            let region = awsCreds.region.trimmingCharacters(in: .whitespaces)
+            if !region.isEmpty {
+                env["AWS_REGION"] = region
+            }
+            let modelID = profile.bedrockModelID.trimmingCharacters(in: .whitespaces)
+            if !modelID.isEmpty {
+                env["ANTHROPIC_MODEL"] = modelID
+            }
+            let settings: [String: Any] = ["env": env]
+            let data = try JSONSerialization.data(withJSONObject: settings,
+                                                  options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: claudeSettingsURL, options: .atomic)
+            try fm.setAttributes([.posixPermissions: NSNumber(value: 0o600)],
+                                 ofItemAtPath: claudeSettingsURL.path)
+        } else if fm.fileExists(atPath: claudeSettingsURL.path),
+                  let data = try? Data(contentsOf: claudeSettingsURL),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let env = json["env"] as? [String: Any],
+                  env["CLAUDE_CODE_USE_BEDROCK"] != nil {
+            try? fm.removeItem(at: claudeSettingsURL)
+        }
+
         // ~/.docker/config.json — Docker stores per-registry HTTP Basic
         // creds here as `auths.<key>.auth = base64("<user>:<password>")`.
         // We write FAKE base64 strings; the proxy substitutes the real

--- a/Sources/AgentCoding/ProfileViews.swift
+++ b/Sources/AgentCoding/ProfileViews.swift
@@ -366,6 +366,8 @@ struct ProfileEditorView: View {
     /// Credentials pane. All sections start collapsed — the user
     /// opens whichever one they need.
     @State private var expandedCredsSections: Set<String> = []
+    @State private var discoveredSSOProfiles: [DiscoveredSSOProfile] = []
+    @State private var awsFolderGranted: Bool = false
 
     /// Snapshot of the host's macOS key-repeat values, captured when
     /// the editor opens. Used as the visible default in the Key
@@ -619,6 +621,7 @@ struct ProfileEditorView: View {
                     isPrimary: draft.tool == t,
                     isEnabled: isToolEnabled(t),
                     spec: bindingForTool(t),
+                    bedrockModelID: $draft.bedrockModelID,
                     onToggleEnabled: { setToolEnabled(t, enabled: $0) },
                     onMakePrimary: { setPrimary(t) },
                     profileDirHint: profileDirHint
@@ -659,6 +662,9 @@ struct ProfileEditorView: View {
                     self.draft.apiKeyRequiresApproval = newValue.requireApproval
                 } else if let i = self.draft.additionalTools.firstIndex(where: { $0.tool == t }) {
                     self.draft.additionalTools[i] = newValue
+                }
+                if newValue.tool == .claude {
+                    self.draft.bedrockEnabled = newValue.authMode == .bedrock
                 }
             }
         )
@@ -1175,27 +1181,153 @@ struct ProfileEditorView: View {
     @ViewBuilder
     private var awsSubsection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            Picker(NSLocalizedString("Auth method", comment: ""),
+                   selection: $draft.awsCredentials.authMode) {
+                Text(NSLocalizedString("Static keys", comment: ""))
+                    .tag(AWSAuthMode.staticKeys)
+                Text(NSLocalizedString("SSO / Identity Center", comment: ""))
+                    .tag(AWSAuthMode.ssoProfile)
+            }
+            .pickerStyle(.segmented)
+            .padding(.bottom, 4)
 
-            LabeledContent(NSLocalizedString("Access key ID", comment: "")) {
-                TextField("AKIA…", text: $draft.awsCredentials.accessKeyID)
-                    .textFieldStyle(.roundedBorder)
-                    .textContentType(.username)
-                    .disableAutocorrection(true)
+            switch draft.awsCredentials.authMode {
+            case .staticKeys:
+                awsStaticKeysFields
+            case .ssoProfile:
+                awsSSOFields
             }
 
-            LabeledContent(NSLocalizedString("Secret access key", comment: "")) {
-                SecureField("•••• ••••", text: $draft.awsCredentials.secretAccessKey)
-                    .textFieldStyle(.roundedBorder)
+            requireApprovalToggle(isOn: $draft.awsCredentials.requireApproval)
+        }
+    }
+
+    @ViewBuilder
+    private var awsStaticKeysFields: some View {
+        Text("Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+        LabeledContent(NSLocalizedString("Access key ID", comment: "")) {
+            TextField("AKIA…", text: $draft.awsCredentials.accessKeyID)
+                .textFieldStyle(.roundedBorder)
+                .textContentType(.username)
+                .disableAutocorrection(true)
+        }
+
+        LabeledContent(NSLocalizedString("Secret access key", comment: "")) {
+            SecureField("•••• ••••", text: $draft.awsCredentials.secretAccessKey)
+                .textFieldStyle(.roundedBorder)
+        }
+
+        LabeledContent(NSLocalizedString("Session token", comment: "")) {
+            SecureField(NSLocalizedString("Optional — STS only", comment: ""),
+                        text: $draft.awsCredentials.sessionToken)
+                .textFieldStyle(.roundedBorder)
+        }
+
+        LabeledContent(NSLocalizedString("Default region", comment: "")) {
+            TextField("us-east-1", text: $draft.awsCredentials.region)
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+        }
+
+        HStack(spacing: 6) {
+            Spacer()
+            Button {
+                if let url = URL(string: "https://console.aws.amazon.com/iam/home#/security_credentials") {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                Label(NSLocalizedString("Open IAM credentials page", comment: ""),
+                      systemImage: "arrow.up.right.square")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+        }
+    }
+
+    @ViewBuilder
+    private var awsSSOFields: some View {
+        Text("Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+        if !awsFolderGranted && !draft.folderPaths.contains(where: { $0.hasSuffix("/.aws") }) {
+            Button {
+                let panel = NSOpenPanel()
+                panel.canChooseDirectories = true
+                panel.canChooseFiles = false
+                panel.allowsMultipleSelection = false
+                panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent(".aws", isDirectory: true)
+                panel.message = NSLocalizedString(
+                    "Grant Bromure read access to your AWS configuration directory.",
+                    comment: "")
+                panel.prompt = NSLocalizedString("Grant Access", comment: "")
+                if panel.runModal() == .OK, let url = panel.url {
+                    if !draft.folderPaths.contains(url.path) {
+                        draft.folderPaths.append(url.path)
+                    }
+                    awsFolderGranted = true
+                    discoveredSSOProfiles = AWSConfigParser.discover(
+                        configPath: url.appendingPathComponent("config").path)
+                }
+            } label: {
+                Label(NSLocalizedString("Grant access to ~/.aws", comment: ""),
+                      systemImage: "folder.badge.plus")
+            }
+            .controlSize(.large)
+        } else {
+            HStack {
+                Picker(NSLocalizedString("SSO profile", comment: ""),
+                       selection: $draft.awsCredentials.ssoProfileName) {
+                    Text("Select a profile…").tag("")
+                    ForEach(discoveredSSOProfiles) { profile in
+                        Text(profile.name).tag(profile.name)
+                    }
+                }
+                .frame(maxWidth: 240)
+
+                Button {
+                    discoveredSSOProfiles = AWSConfigParser.discover()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .help(NSLocalizedString("Refresh profiles", comment: ""))
+            }
+            .onAppear {
+                if discoveredSSOProfiles.isEmpty {
+                    discoveredSSOProfiles = AWSConfigParser.discover()
+                }
+                if draft.folderPaths.contains(where: { $0.hasSuffix("/.aws") }) {
+                    awsFolderGranted = true
+                }
+            }
+            .onChange(of: draft.awsCredentials.ssoProfileName) { _, newValue in
+                if let match = discoveredSSOProfiles.first(where: { $0.name == newValue }) {
+                    draft.awsCredentials.ssoAccountId = match.ssoAccountID
+                    draft.awsCredentials.ssoRoleName = match.ssoRoleName
+                    if draft.awsCredentials.region.isEmpty {
+                        draft.awsCredentials.region = match.region
+                    }
+                }
             }
 
-            LabeledContent(NSLocalizedString("Session token", comment: "")) {
-                SecureField(NSLocalizedString("Optional — STS only", comment: ""),
-                            text: $draft.awsCredentials.sessionToken)
-                    .textFieldStyle(.roundedBorder)
+            if !draft.awsCredentials.ssoAccountId.isEmpty {
+                LabeledContent(NSLocalizedString("Account ID", comment: "")) {
+                    Text(draft.awsCredentials.ssoAccountId)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+                LabeledContent(NSLocalizedString("Role name", comment: "")) {
+                    Text(draft.awsCredentials.ssoRoleName)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
             }
 
             LabeledContent(NSLocalizedString("Default region", comment: "")) {
@@ -1203,24 +1335,9 @@ struct ProfileEditorView: View {
                     .textFieldStyle(.roundedBorder)
                     .disableAutocorrection(true)
             }
-
-            requireApprovalToggle(isOn: $draft.awsCredentials.requireApproval)
-
-            HStack(spacing: 6) {
-                Spacer()
-                Button {
-                    if let url = URL(string: "https://console.aws.amazon.com/iam/home#/security_credentials") {
-                        NSWorkspace.shared.open(url)
-                    }
-                } label: {
-                    Label(NSLocalizedString("Open IAM credentials page", comment: ""),
-                          systemImage: "arrow.up.right.square")
-                        .font(.caption)
-                }
-                .buttonStyle(.borderless)
-            }
         }
     }
+
 
     // MARK: - Container Registries (Docker / GHCR / GitLab CR / private)
 
@@ -2278,6 +2395,7 @@ private struct ToolConfigCard: View {
     let isPrimary: Bool
     let isEnabled: Bool
     @Binding var spec: Profile.ToolSpec
+    @Binding var bedrockModelID: String
     let onToggleEnabled: (Bool) -> Void
     let onMakePrimary: () -> Void
     let profileDirHint: String
@@ -2313,12 +2431,17 @@ private struct ToolConfigCard: View {
             if isEnabled {
                 Picker("Auth", selection: $spec.authMode) {
                     ForEach(Profile.AuthMode.allCases, id: \.self) { m in
-                        Text(m.displayName).tag(m)
+                        if m == .bedrock && tool != .claude {
+                            EmptyView()
+                        } else {
+                            Text(m.displayName).tag(m)
+                        }
                     }
                 }
                 .pickerStyle(.radioGroup)
 
-                if spec.authMode == .token {
+                switch spec.authMode {
+                case .token:
                     SecureField(
                         envVarPlaceholder,
                         text: Binding(
@@ -2333,8 +2456,21 @@ private struct ToolConfigCard: View {
                     }
                     .toggleStyle(.checkbox)
                     .controlSize(.small)
-                } else {
+                case .subscription:
                     Text("You'll run `\(tool.rawValue) login` once inside the VM.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                case .bedrock:
+                    Text("Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    LabeledContent(NSLocalizedString("Model ID", comment: "")) {
+                        TextField("us.anthropic.claude-sonnet-4-6-v1:0",
+                                  text: $bedrockModelID)
+                            .textFieldStyle(.roundedBorder)
+                            .disableAutocorrection(true)
+                    }
+                    Text("Configure AWS credentials (SSO or static keys) in the Credentials → AWS section.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/AgentCoding/ProfileViews.swift
+++ b/Sources/AgentCoding/ProfileViews.swift
@@ -1255,7 +1255,7 @@ struct ProfileEditorView: View {
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
 
-        if !awsFolderGranted && !draft.folderPaths.contains(where: { $0.hasSuffix("/.aws") }) {
+        if !awsFolderGranted {
             Button {
                 let panel = NSOpenPanel()
                 panel.canChooseDirectories = true
@@ -1268,9 +1268,6 @@ struct ProfileEditorView: View {
                     comment: "")
                 panel.prompt = NSLocalizedString("Grant Access", comment: "")
                 if panel.runModal() == .OK, let url = panel.url {
-                    if !draft.folderPaths.contains(url.path) {
-                        draft.folderPaths.append(url.path)
-                    }
                     awsFolderGranted = true
                     discoveredSSOProfiles = AWSConfigParser.discover(
                         configPath: url.appendingPathComponent("config").path)
@@ -1301,10 +1298,11 @@ struct ProfileEditorView: View {
             }
             .onAppear {
                 if discoveredSSOProfiles.isEmpty {
-                    discoveredSSOProfiles = AWSConfigParser.discover()
-                }
-                if draft.folderPaths.contains(where: { $0.hasSuffix("/.aws") }) {
-                    awsFolderGranted = true
+                    let found = AWSConfigParser.discover()
+                    if !found.isEmpty {
+                        discoveredSSOProfiles = found
+                        awsFolderGranted = true
+                    }
                 }
             }
             .onChange(of: draft.awsCredentials.ssoProfileName) { _, newValue in
@@ -1315,25 +1313,6 @@ struct ProfileEditorView: View {
                         draft.awsCredentials.region = match.region
                     }
                 }
-            }
-
-            if !draft.awsCredentials.ssoAccountId.isEmpty {
-                LabeledContent(NSLocalizedString("Account ID", comment: "")) {
-                    Text(draft.awsCredentials.ssoAccountId)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-                LabeledContent(NSLocalizedString("Role name", comment: "")) {
-                    Text(draft.awsCredentials.ssoRoleName)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-            }
-
-            LabeledContent(NSLocalizedString("Default region", comment: "")) {
-                TextField("us-east-1", text: $draft.awsCredentials.region)
-                    .textFieldStyle(.roundedBorder)
-                    .disableAutocorrection(true)
             }
         }
     }
@@ -2464,7 +2443,7 @@ private struct ToolConfigCard: View {
                     Text("Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    LabeledContent(NSLocalizedString("Model ID", comment: "")) {
+                    LabeledContent(NSLocalizedString("Default Model ID", comment: "")) {
                         TextField("us.anthropic.claude-sonnet-4-6-v1:0",
                                   text: $bedrockModelID)
                             .textFieldStyle(.roundedBorder)

--- a/Sources/AgentCoding/SessionDisk.swift
+++ b/Sources/AgentCoding/SessionDisk.swift
@@ -617,6 +617,8 @@ public final class SessionDisk {
                 s += "• `\(spec.tool.rawValue)` — API key already in env.\n"
             case .subscription:
                 s += "• `\(spec.tool.rawValue) login` once, then `\(spec.tool.rawValue)`.\n"
+            case .bedrock:
+                s += "• `\(spec.tool.rawValue)` — using AWS Bedrock credentials.\n"
             }
         }
         return s

--- a/Sources/AgentCoding/de.lproj/Localizable.strings
+++ b/Sources/AgentCoding/de.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "Rollenname";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code authentifiziert sich über AWS Bedrock mit den im AWS-Bereich unten konfigurierten Anmeldedaten.";
-"Model ID" = "Modell-ID";
+"Default Model ID" = "Standard-Modell-ID";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Konfigurieren Sie AWS-Anmeldedaten (SSO oder statische Schlüssel) im Bereich Anmeldedaten → AWS.";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/de.lproj/Localizable.strings
+++ b/Sources/AgentCoding/de.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "Access Key + Secret aus IAM → Benutzer → Sicherheitsanmeldedaten. Das echte Secret erreicht die VM gar nicht — `~/.aws/config` verweist auf ein `credential_process`-Hilfsprogramm, das den echten Access Key zusammen mit einem *gefälschten* Secret ausliefert, sodass das SDK eine zum Scheitern verurteilte Anfrage signiert. Der MITM-Proxy auf dem Host entfernt diese Signatur und signiert mit dem echten Schlüsselmaterial neu, bevor die Anfrage Ihren Mac verlässt. `aws`, terraform, boto3 usw. funktionieren ohne Anpassungen; umgeht etwas den Proxy, lehnt AWS mit InvalidSignatureException ab — Fail-closed.";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "Authentifizierungsmethode";
+"Static keys" = "Statische Schlüssel";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "Authentifizierung über AWS IAM Identity Center (SSO). Gewähren Sie Zugriff auf Ihr ~/.aws-Verzeichnis und wählen Sie dann ein SSO-Profil. Beim Sitzungsstart öffnet sich Ihr Browser zur Anmeldung, falls Ihr zwischengespeichertes Token abgelaufen ist.";
+"Grant Bromure read access to your AWS configuration directory." = "Bromure Lesezugriff auf Ihr AWS-Konfigurationsverzeichnis gewähren.";
+"Grant Access" = "Zugriff gewähren";
+"Grant access to ~/.aws" = "Zugriff auf ~/.aws gewähren";
+"SSO profile" = "SSO-Profil";
+"Select a profile…" = "Profil auswählen…";
+"Refresh profiles" = "Profile aktualisieren";
+"Account ID" = "Konto-ID";
+"Role name" = "Rollenname";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code authentifiziert sich über AWS Bedrock mit den im AWS-Bereich unten konfigurierten Anmeldedaten.";
+"Model ID" = "Modell-ID";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Konfigurieren Sie AWS-Anmeldedaten (SSO oder statische Schlüssel) im Bereich Anmeldedaten → AWS.";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "Angehaltene VM für „%@“ verwerfen?";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "Die freigegebenen Ordner haben sich geändert, seit dieses Profil angehalten wurde. Der Schnappschuss wurde mit dem alten Ordner-Satz gesichert und lässt sich mit dem neuen nicht sicher fortsetzen.\n\nBeim Sichern wird der angehaltene Zustand verworfen. Der nächste Start ist ein Kaltstart. Dateien im persönlichen Profil-Ordner und in den freigegebenen Ordnern selbst bleiben unberührt.";

--- a/Sources/AgentCoding/en.lproj/Localizable.strings
+++ b/Sources/AgentCoding/en.lproj/Localizable.strings
@@ -148,7 +148,7 @@
 "Role name" = "Role name";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below.";
-"Model ID" = "Model ID";
+"Default Model ID" = "Default Model ID";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section.";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/en.lproj/Localizable.strings
+++ b/Sources/AgentCoding/en.lproj/Localizable.strings
@@ -133,6 +133,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed.";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "Auth method";
+"Static keys" = "Static keys";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login.";
+"Grant Bromure read access to your AWS configuration directory." = "Grant Bromure read access to your AWS configuration directory.";
+"Grant Access" = "Grant Access";
+"Grant access to ~/.aws" = "Grant access to ~/.aws";
+"SSO profile" = "SSO profile";
+"Select a profile…" = "Select a profile…";
+"Refresh profiles" = "Refresh profiles";
+"Account ID" = "Account ID";
+"Role name" = "Role name";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below.";
+"Model ID" = "Model ID";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section.";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "Discard suspended VM for “%@”?";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected.";

--- a/Sources/AgentCoding/es.lproj/Localizable.strings
+++ b/Sources/AgentCoding/es.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "Nombre de rol";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code se autenticará mediante AWS Bedrock usando las credenciales configuradas en la sección de AWS a continuación.";
-"Model ID" = "ID de modelo";
+"Default Model ID" = "ID de modelo predeterminado";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configure las credenciales de AWS (SSO o claves estáticas) en la sección Credenciales → AWS.";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/es.lproj/Localizable.strings
+++ b/Sources/AgentCoding/es.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "Clave de acceso + secreto desde IAM → Usuarios → Credenciales de seguridad. El secreto real nunca llega a la VM — `~/.aws/config` apunta a un asistente `credential_process` que entrega la clave real junto con un secreto *falso*, por lo que el SDK firma una solicitud condenada a fallar. El proxy MITM del host elimina esa firma y vuelve a firmar con el material real antes de que la solicitud salga de tu Mac. `aws`, terraform, boto3, etc. funcionan sin configuración; si algo evita el proxy, AWS rechaza con InvalidSignatureException — fail-closed.";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "Método de autenticación";
+"Static keys" = "Claves estáticas";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "Autenticación mediante AWS IAM Identity Center (SSO). Conceda acceso a su directorio ~/.aws y seleccione un perfil SSO. Al iniciar la sesión, si su token en caché ha expirado, se abrirá el navegador para iniciar sesión.";
+"Grant Bromure read access to your AWS configuration directory." = "Conceder a Bromure acceso de lectura a su directorio de configuración de AWS.";
+"Grant Access" = "Conceder acceso";
+"Grant access to ~/.aws" = "Conceder acceso a ~/.aws";
+"SSO profile" = "Perfil SSO";
+"Select a profile…" = "Seleccionar un perfil…";
+"Refresh profiles" = "Actualizar perfiles";
+"Account ID" = "ID de cuenta";
+"Role name" = "Nombre de rol";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code se autenticará mediante AWS Bedrock usando las credenciales configuradas en la sección de AWS a continuación.";
+"Model ID" = "ID de modelo";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configure las credenciales de AWS (SSO o claves estáticas) en la sección Credenciales → AWS.";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "¿Descartar la VM suspendida de “%@”?";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "Las carpetas compartidas han cambiado desde que se suspendió este perfil. La instantánea se guardó con el conjunto antiguo de carpetas y no se puede reanudar con seguridad con el nuevo.\n\nAl guardar se descartará el estado suspendido. El próximo inicio será en frío. Los archivos de la carpeta personal del perfil y de las carpetas compartidas no se ven afectados.";

--- a/Sources/AgentCoding/fr.lproj/Localizable.strings
+++ b/Sources/AgentCoding/fr.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "Nom du rôle";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code s'authentifiera via AWS Bedrock en utilisant les identifiants configurés dans la section AWS ci-dessous.";
-"Model ID" = "ID de modèle";
+"Default Model ID" = "ID de modèle par défaut";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configurez les identifiants AWS (SSO ou clés statiques) dans la section Identifiants → AWS.";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/fr.lproj/Localizable.strings
+++ b/Sources/AgentCoding/fr.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "Clé d'accès + secret depuis IAM → Utilisateurs → Identifiants de sécurité. Le vrai secret n'atteint jamais la VM — `~/.aws/config` pointe vers un assistant `credential_process` qui livre la vraie clé d'accès avec un secret *factice*, ce qui fait que le SDK signe une requête vouée à l'échec. Le proxy MITM de l'hôte supprime cette signature et la refait avec le vrai matériau avant que la requête ne quitte votre Mac. `aws`, terraform, boto3, etc. fonctionnent d'emblée ; si quelque chose contourne le proxy, AWS rejette avec InvalidSignatureException — fail-closed.";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "Méthode d'authentification";
+"Static keys" = "Clés statiques";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "Authentification via AWS IAM Identity Center (SSO). Accordez l'accès à votre répertoire ~/.aws, puis sélectionnez un profil SSO. Au démarrage de la session, si votre jeton en cache a expiré, votre navigateur s'ouvrira pour la connexion.";
+"Grant Bromure read access to your AWS configuration directory." = "Accorder à Bromure l'accès en lecture à votre répertoire de configuration AWS.";
+"Grant Access" = "Autoriser l'accès";
+"Grant access to ~/.aws" = "Autoriser l'accès à ~/.aws";
+"SSO profile" = "Profil SSO";
+"Select a profile…" = "Sélectionner un profil…";
+"Refresh profiles" = "Actualiser les profils";
+"Account ID" = "ID de compte";
+"Role name" = "Nom du rôle";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code s'authentifiera via AWS Bedrock en utilisant les identifiants configurés dans la section AWS ci-dessous.";
+"Model ID" = "ID de modèle";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configurez les identifiants AWS (SSO ou clés statiques) dans la section Identifiants → AWS.";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "Abandonner la VM suspendue pour « %@ » ?";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "Les dossiers partagés ont changé depuis la mise en pause de ce profil. L'instantané a été enregistré avec l'ancien jeu de partages et ne peut pas être repris en toute sécurité avec le nouveau.\n\nL'enregistrement abandonnera l'état suspendu. Le prochain lancement démarrera à froid. Les fichiers du dossier personnel du profil et des dossiers partagés ne sont pas affectés.";

--- a/Sources/AgentCoding/ja.lproj/Localizable.strings
+++ b/Sources/AgentCoding/ja.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "ロール名";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code は下の AWS セクションで設定された認証情報を使用して AWS Bedrock で認証します。";
-"Model ID" = "モデル ID";
+"Default Model ID" = "デフォルトモデル ID";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "認証情報 → AWS セクションで AWS 認証情報（SSO または静的キー）を設定してください。";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/ja.lproj/Localizable.strings
+++ b/Sources/AgentCoding/ja.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "IAM → ユーザー → セキュリティ認証情報からアクセスキーとシークレットを取得します。本物のシークレットは VM にまったく到達しません — `~/.aws/config` は `credential_process` ヘルパーを指していて、本物のアクセスキーと*ニセの*シークレットを返します。そのため SDK は失敗が確定したリクエストに署名します。ホスト側の MITM プロキシがその署名を取り除き、本物の鍵情報で再署名してから Mac の外に送出します。`aws`、terraform、boto3 などはそのまま動作します。プロキシを迂回した場合は AWS が InvalidSignatureException で拒否します — フェイルクローズです。";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "認証方式";
+"Static keys" = "静的キー";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "AWS IAM Identity Center (SSO) で認証します。~/.aws ディレクトリへのアクセスを許可し、SSO プロファイルを選択してください。セッション開始時にキャッシュされたトークンが期限切れの場合、ブラウザが開いてログインを求めます。";
+"Grant Bromure read access to your AWS configuration directory." = "Bromure に AWS 設定ディレクトリへの読み取りアクセスを許可します。";
+"Grant Access" = "アクセスを許可";
+"Grant access to ~/.aws" = "~/.aws へのアクセスを許可";
+"SSO profile" = "SSO プロファイル";
+"Select a profile…" = "プロファイルを選択…";
+"Refresh profiles" = "プロファイルを更新";
+"Account ID" = "アカウント ID";
+"Role name" = "ロール名";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code は下の AWS セクションで設定された認証情報を使用して AWS Bedrock で認証します。";
+"Model ID" = "モデル ID";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "認証情報 → AWS セクションで AWS 認証情報（SSO または静的キー）を設定してください。";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "「%@」の中断中の VM を破棄しますか？";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "このプロファイルが中断されてから、共有フォルダが変更されました。スナップショットは以前の共有セットに対して保存されているため、新しい共有セットでは安全に再開できません。\n\n保存すると中断状態は破棄されます。次回の起動はコールドブートになります。プロファイルのホームディレクトリと共有フォルダ内のファイルは影響を受けません。";

--- a/Sources/AgentCoding/pt.lproj/Localizable.strings
+++ b/Sources/AgentCoding/pt.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "Chave de acesso + segredo em IAM → Usuários → Credenciais de segurança. O segredo real nunca chega à VM — `~/.aws/config` aponta para um auxiliar `credential_process` que devolve a chave de acesso real com um segredo *falso*, fazendo com que o SDK assine uma requisição fadada ao fracasso. O proxy MITM do host remove essa assinatura e reassina com o material real antes da requisição sair do seu Mac. `aws`, terraform, boto3, etc. funcionam de imediato; se algo contornar o proxy, a AWS rejeita com InvalidSignatureException — fail-closed.";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "Método de autenticação";
+"Static keys" = "Chaves estáticas";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "Autenticação via AWS IAM Identity Center (SSO). Conceda acesso ao diretório ~/.aws e selecione um perfil SSO. Ao iniciar a sessão, se o token em cache tiver expirado, o navegador será aberto para login.";
+"Grant Bromure read access to your AWS configuration directory." = "Conceder ao Bromure acesso de leitura ao diretório de configuração da AWS.";
+"Grant Access" = "Conceder acesso";
+"Grant access to ~/.aws" = "Conceder acesso a ~/.aws";
+"SSO profile" = "Perfil SSO";
+"Select a profile…" = "Selecionar um perfil…";
+"Refresh profiles" = "Atualizar perfis";
+"Account ID" = "ID da conta";
+"Role name" = "Nome da função";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "O Claude Code será autenticado via AWS Bedrock usando as credenciais configuradas na seção AWS abaixo.";
+"Model ID" = "ID do modelo";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configure as credenciais da AWS (SSO ou chaves estáticas) na seção Credenciais → AWS.";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "Descartar a VM suspensa de “%@”?";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "As pastas compartilhadas mudaram desde que este perfil foi suspenso. O snapshot foi salvo com o conjunto antigo de pastas e não pode ser retomado com segurança com o novo.\n\nSalvar descartará o estado suspenso. A próxima execução iniciará a frio. Os arquivos da pasta pessoal do perfil e das pastas compartilhadas não são afetados.";

--- a/Sources/AgentCoding/pt.lproj/Localizable.strings
+++ b/Sources/AgentCoding/pt.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "Nome da função";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "O Claude Code será autenticado via AWS Bedrock usando as credenciais configuradas na seção AWS abaixo.";
-"Model ID" = "ID do modelo";
+"Default Model ID" = "ID do modelo padrão";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "Configure as credenciais da AWS (SSO ou chaves estáticas) na seção Credenciais → AWS.";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/zh-Hans.lproj/Localizable.strings
+++ b/Sources/AgentCoding/zh-Hans.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "在 IAM → 用户 → 安全凭证 中获取访问密钥和秘密密钥。真正的秘密密钥根本不会进入虚拟机 —— `~/.aws/config` 指向一个 `credential_process` 辅助程序，该程序提供真正的访问密钥和一个*假的*秘密密钥，因此 SDK 签名的请求注定会失败。主机端的 MITM 代理会去掉该签名，并在请求离开你的 Mac 之前用真实的密钥材料重新签名。`aws`、terraform、boto3 等可开箱即用；如果有任何东西绕过代理，AWS 会以 InvalidSignatureException 拒绝该请求 —— 失败时关闭（fail-closed）。";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "认证方式";
+"Static keys" = "静态密钥";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "通过 AWS IAM Identity Center (SSO) 进行认证。授予对 ~/.aws 目录的访问权限，然后选择 SSO 配置文件。会话启动时，如果缓存的令牌已过期，浏览器将打开进行登录。";
+"Grant Bromure read access to your AWS configuration directory." = "授予 Bromure 对 AWS 配置目录的读取权限。";
+"Grant Access" = "授予访问权限";
+"Grant access to ~/.aws" = "授予对 ~/.aws 的访问权限";
+"SSO profile" = "SSO 配置文件";
+"Select a profile…" = "选择配置文件…";
+"Refresh profiles" = "刷新配置文件";
+"Account ID" = "账户 ID";
+"Role name" = "角色名称";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code 将使用下方 AWS 部分中配置的凭证通过 AWS Bedrock 进行认证。";
+"Model ID" = "模型 ID";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "在凭证 → AWS 部分中配置 AWS 凭证（SSO 或静态密钥）。";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "丢弃“%@”的已挂起虚拟机？";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "自该配置文件挂起以来，共享文件夹已发生变化。快照是基于旧的共享集保存的，无法安全地以新的共享集恢复。\n\n保存将丢弃挂起状态。下次启动将冷启动。配置文件的个人主目录及共享文件夹中的文件不受影响。";

--- a/Sources/AgentCoding/zh-Hans.lproj/Localizable.strings
+++ b/Sources/AgentCoding/zh-Hans.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "角色名称";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code 将使用下方 AWS 部分中配置的凭证通过 AWS Bedrock 进行认证。";
-"Model ID" = "模型 ID";
+"Default Model ID" = "默认模型 ID";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "在凭证 → AWS 部分中配置 AWS 凭证（SSO 或静态密钥）。";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Sources/AgentCoding/zh-Hant.lproj/Localizable.strings
+++ b/Sources/AgentCoding/zh-Hant.lproj/Localizable.strings
@@ -132,6 +132,24 @@
 /* Editor — Credentials → AWS */
 "Access key + secret from IAM → Users → Security credentials. The real secret never reaches the VM at all — `~/.aws/config` points at a `credential_process` helper that vends the real access key with a *fake* secret, so the SDK signs a doomed request. The host's MITM proxy strips that signature and re-signs with the real material before the request leaves your Mac. `aws`, terraform, boto3 etc. work out of the box; if anything bypasses the proxy, AWS rejects with InvalidSignatureException — fail-closed." = "在 IAM → 使用者 → 安全憑證 中取得存取金鑰和秘密金鑰。真正的秘密金鑰根本不會到達虛擬機 —— `~/.aws/config` 指向一個 `credential_process` 輔助程式，該程式會將真正的存取金鑰與一個*偽造的*秘密金鑰一起回傳，因此 SDK 簽署的請求註定會失敗。主機端的 MITM 代理會去除該簽章，並在請求離開你的 Mac 之前以真實的金鑰材料重新簽章。`aws`、terraform、boto3 等可直接運作；如果有任何東西繞過代理，AWS 會以 InvalidSignatureException 拒絕該請求 —— 失敗時關閉（fail-closed）。";
 
+/* Editor — Credentials → AWS SSO & Bedrock */
+"Auth method" = "認證方式";
+"Static keys" = "靜態金鑰";
+"SSO / Identity Center" = "SSO / Identity Center";
+"Authenticate via AWS IAM Identity Center (SSO). Grant access to your ~/.aws directory, then select an SSO profile. On session start, if your cached token is expired, your browser will open for login." = "透過 AWS IAM Identity Center (SSO) 進行認證。授予對 ~/.aws 目錄的存取權限，然後選擇 SSO 設定檔。工作階段啟動時，若快取的權杖已過期，瀏覽器將開啟進行登入。";
+"Grant Bromure read access to your AWS configuration directory." = "授予 Bromure 對 AWS 設定目錄的讀取權限。";
+"Grant Access" = "授予存取權限";
+"Grant access to ~/.aws" = "授予對 ~/.aws 的存取權限";
+"SSO profile" = "SSO 設定檔";
+"Select a profile…" = "選擇設定檔…";
+"Refresh profiles" = "重新整理設定檔";
+"Account ID" = "帳戶 ID";
+"Role name" = "角色名稱";
+"Bedrock (AWS)" = "Bedrock (AWS)";
+"Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code 將使用下方 AWS 區段中設定的憑證透過 AWS Bedrock 進行認證。";
+"Model ID" = "模型 ID";
+"Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "在憑證 → AWS 區段中設定 AWS 憑證（SSO 或靜態金鑰）。";
+
 /* Alert: shared folders changed while a saved VM state exists */
 "Discard suspended VM for “%@”?" = "要丟棄「%@」的暫停虛擬機嗎？";
 "The shared folders changed since this profile was suspended. The snapshot was saved against the old share set, so it can't be safely resumed with the new one.\n\nSaving will discard the suspended state. The next launch will cold-boot. Files in the per-profile home directory and on the shared folders themselves are unaffected." = "自此設定檔暫停以來，共享資料夾已變更。快照是以舊的共享集儲存的，無法以新的共享集安全地繼續。\n\n儲存將丟棄暫停狀態。下次啟動將是冷開機。設定檔的個人主目錄與共享資料夾中的檔案不受影響。";

--- a/Sources/AgentCoding/zh-Hant.lproj/Localizable.strings
+++ b/Sources/AgentCoding/zh-Hant.lproj/Localizable.strings
@@ -147,7 +147,7 @@
 "Role name" = "角色名稱";
 "Bedrock (AWS)" = "Bedrock (AWS)";
 "Claude Code will authenticate via AWS Bedrock using the credentials configured in the AWS section below." = "Claude Code 將使用下方 AWS 區段中設定的憑證透過 AWS Bedrock 進行認證。";
-"Model ID" = "模型 ID";
+"Default Model ID" = "預設模型 ID";
 "Configure AWS credentials (SSO or static keys) in the Credentials → AWS section." = "在憑證 → AWS 區段中設定 AWS 憑證（SSO 或靜態金鑰）。";
 
 /* Alert: shared folders changed while a saved VM state exists */

--- a/Tests/AgentCodingTests/AWSConfigParserTests.swift
+++ b/Tests/AgentCodingTests/AWSConfigParserTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+@testable import bromure_ac
+
+@Suite("AWSConfigParser")
+struct AWSConfigParserTests {
+
+    private func writeTempConfig(_ contents: String) throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bromure-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("config").path
+        try contents.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    @Test("Discovers SSO profiles with all required fields")
+    func discoverBasic() throws {
+        let config = """
+        [profile dev]
+        sso_start_url = https://my-sso.awsapps.com/start
+        sso_account_id = 123456789012
+        sso_role_name = AdministratorAccess
+        sso_region = us-east-1
+        region = us-west-2
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.count == 1)
+        #expect(profiles[0].name == "dev")
+        #expect(profiles[0].ssoStartURL == "https://my-sso.awsapps.com/start")
+        #expect(profiles[0].ssoAccountID == "123456789012")
+        #expect(profiles[0].ssoRoleName == "AdministratorAccess")
+        #expect(profiles[0].ssoRegion == "us-east-1")
+        #expect(profiles[0].region == "us-west-2")
+    }
+
+    @Test("Skips profiles missing required SSO fields")
+    func skipIncomplete() throws {
+        let config = """
+        [profile complete]
+        sso_start_url = https://my-sso.awsapps.com/start
+        sso_account_id = 123456789012
+        sso_role_name = ReadOnly
+        sso_region = us-east-1
+        region = us-east-1
+
+        [profile missing-role]
+        sso_start_url = https://my-sso.awsapps.com/start
+        sso_account_id = 123456789012
+        sso_region = us-east-1
+        region = us-east-1
+
+        [profile static-only]
+        region = us-west-2
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.count == 1)
+        #expect(profiles[0].name == "complete")
+    }
+
+    @Test("Handles [default] section")
+    func defaultSection() throws {
+        let config = """
+        [default]
+        sso_start_url = https://default.awsapps.com/start
+        sso_account_id = 111111111111
+        sso_role_name = DefaultRole
+        sso_region = eu-west-1
+        region = eu-west-1
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.count == 1)
+        #expect(profiles[0].name == "default")
+    }
+
+    @Test("Discovers multiple profiles")
+    func multipleProfiles() throws {
+        let config = """
+        [profile dev]
+        sso_start_url = https://sso.awsapps.com/start
+        sso_account_id = 111111111111
+        sso_role_name = DevRole
+        sso_region = us-east-1
+        region = us-east-1
+
+        [profile staging]
+        sso_start_url = https://sso.awsapps.com/start
+        sso_account_id = 222222222222
+        sso_role_name = StagingRole
+        sso_region = us-east-1
+        region = us-west-2
+
+        [profile prod]
+        sso_start_url = https://sso.awsapps.com/start
+        sso_account_id = 333333333333
+        sso_role_name = ProdRole
+        sso_region = us-east-1
+        region = eu-west-1
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.count == 3)
+        let names = profiles.map(\.name)
+        #expect(names.contains("dev"))
+        #expect(names.contains("staging"))
+        #expect(names.contains("prod"))
+    }
+
+    @Test("Resolves sso-session references")
+    func ssoSession() throws {
+        let config = """
+        [sso-session my-session]
+        sso_start_url = https://shared.awsapps.com/start
+        sso_region = us-east-1
+
+        [profile session-user]
+        sso_session = my-session
+        sso_account_id = 444444444444
+        sso_role_name = SessionRole
+        region = us-east-2
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.count == 1)
+        #expect(profiles[0].name == "session-user")
+        #expect(profiles[0].ssoStartURL == "https://shared.awsapps.com/start")
+        #expect(profiles[0].ssoRegion == "us-east-1")
+        #expect(profiles[0].ssoAccountID == "444444444444")
+        #expect(profiles[0].ssoRoleName == "SessionRole")
+        #expect(profiles[0].region == "us-east-2")
+    }
+
+    @Test("Returns empty array for missing config file")
+    func missingFile() {
+        let profiles = AWSConfigParser.discover(configPath: "/nonexistent/path/config")
+        #expect(profiles.isEmpty)
+    }
+
+    @Test("Returns empty array for empty config file")
+    func emptyFile() throws {
+        let path = try writeTempConfig("")
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.isEmpty)
+    }
+
+    @Test("Handles inline comments and whitespace")
+    func commentsAndWhitespace() throws {
+        let config = """
+        [profile trimmed]
+          sso_start_url = https://sso.awsapps.com/start
+          sso_account_id = 555555555555
+          sso_role_name = TrimRole
+          sso_region = us-east-1
+          region = us-east-1
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles.count == 1)
+        #expect(profiles[0].ssoStartURL == "https://sso.awsapps.com/start")
+    }
+
+    @Test("Profiles are Identifiable by name")
+    func identifiable() throws {
+        let config = """
+        [profile test-id]
+        sso_start_url = https://sso.awsapps.com/start
+        sso_account_id = 666666666666
+        sso_role_name = IDRole
+        sso_region = us-east-1
+        region = us-east-1
+        """
+        let path = try writeTempConfig(config)
+        defer { try? FileManager.default.removeItem(atPath: URL(fileURLWithPath: path).deletingLastPathComponent().path) }
+
+        let profiles = AWSConfigParser.discover(configPath: path)
+        #expect(profiles[0].id == "test-id")
+    }
+}

--- a/Tests/AgentCodingTests/AWSSSOResolverTests.swift
+++ b/Tests/AgentCodingTests/AWSSSOResolverTests.swift
@@ -1,0 +1,115 @@
+import CommonCrypto
+import Foundation
+import Testing
+@testable import bromure_ac
+
+@Suite("AWSSSOResolver")
+struct AWSSSOResolverTests {
+
+    // MARK: - Error descriptions
+
+    @Test("All error cases have non-empty descriptions")
+    func errorDescriptions() {
+        let errors: [AWSSSOResolver.Error] = [
+            .noProfile("test-profile"),
+            .loginFailed("connection refused"),
+            .tokenExpired,
+            .credentialFetchFailed("HTTP 403"),
+        ]
+        for error in errors {
+            let desc = error.errorDescription ?? ""
+            #expect(!desc.isEmpty, "Error \(error) should have a description")
+        }
+    }
+
+    @Test("noProfile includes profile name")
+    func noProfileIncludesName() {
+        let error = AWSSSOResolver.Error.noProfile("my-dev-profile")
+        #expect(error.errorDescription!.contains("my-dev-profile"))
+    }
+
+    @Test("loginFailed includes reason")
+    func loginFailedIncludesReason() {
+        let error = AWSSSOResolver.Error.loginFailed("user cancelled")
+        #expect(error.errorDescription!.contains("user cancelled"))
+    }
+
+    @Test("credentialFetchFailed includes reason")
+    func credentialFetchFailedIncludesReason() {
+        let error = AWSSSOResolver.Error.credentialFetchFailed("HTTP 500: Internal Server Error")
+        #expect(error.errorDescription!.contains("HTTP 500"))
+    }
+
+    // MARK: - ResolvedAWSCredentials
+
+    @Test("ResolvedAWSCredentials stores all fields")
+    func resolvedCredsFields() {
+        let expiry = Date().addingTimeInterval(3600)
+        let creds = ResolvedAWSCredentials(
+            accessKeyID: "AKIAIOSFODNN7EXAMPLE",
+            secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            sessionToken: "FwoGZXIvYXdzEBY...",
+            region: "us-west-2",
+            expiration: expiry
+        )
+        #expect(creds.accessKeyID == "AKIAIOSFODNN7EXAMPLE")
+        #expect(creds.secretAccessKey == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        #expect(creds.sessionToken == "FwoGZXIvYXdzEBY...")
+        #expect(creds.region == "us-west-2")
+        #expect(creds.expiration == expiry)
+    }
+
+    // MARK: - Resolve with missing profile
+
+    @Test("Resolve throws noProfile for unknown profile name")
+    func resolveUnknownProfile() async {
+        do {
+            _ = try await AWSSSOResolver.resolve(
+                profileName: "nonexistent-profile-\(UUID().uuidString)",
+                triggerLoginIfNeeded: false
+            )
+            #expect(Bool(false), "Should have thrown")
+        } catch let error as AWSSSOResolver.Error {
+            switch error {
+            case .noProfile(let name):
+                #expect(name.contains("nonexistent-profile"))
+            default:
+                #expect(Bool(false), "Expected noProfile, got \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Token cache SHA1 consistency
+
+    @Test("SHA1 hash of start URL matches AWS CLI convention")
+    func sha1Consistency() {
+        let input = "https://my-sso-portal.awsapps.com/start"
+        let data = Data(input.utf8)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes { ptr in
+            _ = CC_SHA1(ptr.baseAddress, CC_LONG(data.count), &digest)
+        }
+        let hash = digest.map { String(format: "%02x", $0) }.joined()
+
+        #expect(hash.count == 40)
+        #expect(hash.allSatisfy { $0.isHexDigit })
+    }
+
+    // MARK: - Refresh loop cancellation
+
+    @Test("Refresh loop task can be cancelled")
+    func refreshLoopCancellation() async throws {
+        let task = AWSSSOResolver.startRefreshLoop(
+            profileName: "nonexistent-\(UUID().uuidString)",
+            initialExpiration: Date().addingTimeInterval(1),
+            onRefresh: { _ in },
+            onError: { _ in }
+        )
+
+        task.cancel()
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(task.isCancelled)
+    }
+}


### PR DESCRIPTION
## Summary

Adds AWS SSO (IAM Identity Center) authentication and Claude Code Bedrock support to Bromure Agentic Coding, enabling enterprise users to authenticate via SSO and run Claude Code on Bedrock without manual credential management.

- **AWS SSO profile discovery**: New `AWSConfigParser` reads `~/.aws/config` on the host (after explicit user approval via NSOpenPanel) and populates a dropdown of available SSO profiles. Handles `[profile X]`, `[default]`, and `[sso-session X]` blocks.
- **SSO token resolution**: New `AWSSSOResolver` reads the host-side `~/.aws/sso/cache/` to find cached SSO tokens, calls the GetRoleCredentials API to get temporary IAM credentials, and feeds them into the existing MITM SigV4 re-signing pipeline. Supports AWS CLI v2 sso-session cache naming (SHA1 of startUrl|region, session name matching, and content-based fallback). If tokens are expired, triggers `aws sso login` to open the user's browser.
- **Bedrock auth mode**: Adds "Bedrock (AWS)" as a third auth option on the Claude agent card (alongside API token and Subscription). When selected, writes `~/.claude/settings.json` into the VM with `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, and optional `ANTHROPIC_MODEL`.
- **Background credential refresh**: Starts a background task that refreshes temporary IAM credentials ~5 minutes before expiry, so long sessions don't lose AWS access.
- **Security model preserved**: The real AWS secret key never enters the VM. SSO resolution happens entirely on the host. The VM's `credential_process` receives the real AKID + a fake secret; the host proxy re-signs requests with the real material. Fail-closed if the proxy is bypassed.
- **Localization**: 16 new string keys across all 8 language files (en, de, es, fr, ja, pt, zh-Hans, zh-Hant).
- **Unit tests**: 17 tests covering `AWSConfigParser` (profile discovery, sso-session resolution, edge cases) and `AWSSSOResolver` (error descriptions, credential fields, resolve behavior, refresh loop cancellation).

## Data model changes

- `AWSAuthMode` enum (`.staticKeys`, `.ssoProfile`) on `AWSCredentials`
- `ssoProfileName`, `ssoAccountId`, `ssoRoleName` fields on `AWSCredentials`
- `.bedrock` case added to `Profile.AuthMode`
- `bedrockEnabled` and `bedrockModelID` fields on `Profile`
- All new fields use `decodeIfPresent` with backward-compatible defaults

## New files

| File | Purpose |
|------|---------|
| `Sources/AgentCoding/AWSConfigParser.swift` | Pure-Swift INI parser for `~/.aws/config` |
| `Sources/AgentCoding/AWSSSOResolver.swift` | Host-side SSO token resolution + GetRoleCredentials + refresh loop |
| `Tests/AgentCodingTests/AWSConfigParserTests.swift` | 10 tests for config parser |
| `Tests/AgentCodingTests/AWSSSOResolverTests.swift` | 7 tests for SSO resolver |

## Security scan

Opengrep SAST scan (v1.20.0, 1059 rules) run against all modified files:

```
Ran 49 rules on 6 files: 0 findings.
```

## Test plan

- [x] Unit tests pass (`swift test --filter AgentCodingTests` — 17/17)
- [x] Existing tests unaffected (`swift test --filter BromureTests` — pre-existing E2E failures only)
- [x] Manual test: SSO profile discovery populates dropdown from `~/.aws/config`
- [x] Manual test: SSO token resolution succeeds with cached tokens (no browser prompt)
- [x] Manual test: SSO login triggers browser when tokens are expired
- [x] Manual test: `aws sts get-caller-identity` works inside VM with SSO credentials
- [x] Manual test: Claude Code launches on Bedrock inside VM (`~/.claude/settings.json` written correctly)
- [x] Manual test: Static keys auth mode still works unchanged
- [x] Manual test: Bedrock auth mode shows "Default Model ID" field on Claude agent card
- [x] Opengrep SAST scan: 0 findings