### PR TITLE
Add user extension support with curated list and custom URL entry

### DIFF
--- a/Sources/Browser/ProfileSettingsView.swift
+++ b/Sources/Browser/ProfileSettingsView.swift
@@ -124,6 +124,7 @@ struct ProfileSettingsView: View {
     @State private var extensionURL = ""
     @State private var extensionImportError: String?
     @State private var extensionDownloading = false
+    @State private var showDisableNativeTabsAlert = false
 
     // IKEv2 keychain-backed secrets (not stored in profile JSON)
     @State private var ikev2Password: String = ""
@@ -608,6 +609,12 @@ struct ProfileSettingsView: View {
                 description: "Hide Chromium\u{2019}s tab strip and address bar, and render them as native macOS toolbar items instead. Tabs, favicons, the URL bar, and a share button appear in the window\u{2019}s titlebar \u{2014} so the page uses the full window and the browser feels like a native Mac app.",
                 isOn: $draft.settings.nativeChrome
             )
+            .disabled(draft.settings.extensionsEnabled)
+            if draft.settings.extensionsEnabled {
+                Text("Native Tabs is disabled because extensions are enabled. Disable extensions first to re-enable Native Tabs.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             settingsDivider
 
@@ -827,57 +834,92 @@ struct ProfileSettingsView: View {
         VStack(alignment: .leading, spacing: 20) {
             sectionHeader("Extensions", subtitle: "Add browser extensions to this profile")
 
-            // Curated extensions
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Recommended").font(.headline)
-                Text("Popular privacy and security extensions. Toggling an extension will download it on first use.")
-                    .settingDescription()
-
-                VStack(spacing: 0) {
-                    ForEach(CuratedExtensions.all) { curated in
-                        let isEnabled = draft.settings.userExtensions.contains { $0.extensionID == curated.extensionID && $0.enabled }
-                        HStack {
-                            Image(systemName: "puzzlepiece.extension.fill")
-                                .foregroundStyle(.secondary)
-                            Text(curated.name)
-                            Spacer()
-                            Toggle("", isOn: Binding(
-                                get: { isEnabled },
-                                set: { on in
-                                    if on {
-                                        if let idx = draft.settings.userExtensions.firstIndex(where: { $0.extensionID == curated.extensionID }) {
-                                            draft.settings.userExtensions[idx].enabled = true
-                                        } else {
-                                            var ext = curated
-                                            ext.enabled = true
-                                            draft.settings.userExtensions.append(ext)
-                                            Task { try? await ExtensionCache.shared.download(extensionID: curated.extensionID) }
-                                        }
-                                    } else {
-                                        if let idx = draft.settings.userExtensions.firstIndex(where: { $0.extensionID == curated.extensionID }) {
-                                            draft.settings.userExtensions[idx].enabled = false
-                                        }
-                                    }
+            // Enable Extensions master toggle
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle(
+                    "Enable Extensions",
+                    isOn: Binding(
+                        get: { draft.settings.extensionsEnabled },
+                        set: { on in
+                            if on {
+                                if draft.settings.nativeChrome {
+                                    showDisableNativeTabsAlert = true
+                                } else {
+                                    draft.settings.extensionsEnabled = true
                                 }
-                            ))
-                            .toggleStyle(.switch)
-                            .labelsHidden()
+                            } else {
+                                draft.settings.extensionsEnabled = false
+                            }
                         }
-                        .padding(.vertical, 6)
-                        .padding(.horizontal, 10)
-                        if curated.id != CuratedExtensions.all.last?.id {
-                            Divider()
-                        }
-                    }
+                    )
+                )
+                Text("Extensions require Chrome's built-in toolbar. Enabling extensions will disable Native Tabs for this profile.")
+                    .settingDescription()
+            }
+            .alert("Disable Native Tabs?", isPresented: $showDisableNativeTabsAlert) {
+                Button("Disable Native Tabs") {
+                    draft.settings.nativeChrome = false
+                    draft.settings.extensionsEnabled = true
                 }
-                .background(.background.secondary)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Extensions require Chrome's native toolbar to display icons and popups. Native Tabs will be turned off for this profile.")
             }
 
-            settingsDivider
+            if draft.settings.extensionsEnabled {
+                settingsDivider
 
-            // Custom extensions behind a disclosure group
-            DisclosureGroup("Custom Extensions") {
+                // Curated extensions
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Recommended").font(.headline)
+                    Text("Popular privacy and security extensions. Toggling an extension will download it on first use.")
+                        .settingDescription()
+
+                    VStack(spacing: 0) {
+                        ForEach(CuratedExtensions.all) { curated in
+                            let isEnabled = draft.settings.userExtensions.contains { $0.extensionID == curated.extensionID && $0.enabled }
+                            HStack {
+                                Image(systemName: "puzzlepiece.extension.fill")
+                                    .foregroundStyle(.secondary)
+                                Text(curated.name)
+                                Spacer()
+                                Toggle("", isOn: Binding(
+                                    get: { isEnabled },
+                                    set: { on in
+                                        if on {
+                                            if let idx = draft.settings.userExtensions.firstIndex(where: { $0.extensionID == curated.extensionID }) {
+                                                draft.settings.userExtensions[idx].enabled = true
+                                            } else {
+                                                var ext = curated
+                                                ext.enabled = true
+                                                draft.settings.userExtensions.append(ext)
+                                                Task { try? await ExtensionCache.shared.download(extensionID: curated.extensionID) }
+                                            }
+                                        } else {
+                                            if let idx = draft.settings.userExtensions.firstIndex(where: { $0.extensionID == curated.extensionID }) {
+                                                draft.settings.userExtensions[idx].enabled = false
+                                            }
+                                        }
+                                    }
+                                ))
+                                .toggleStyle(.switch)
+                                .labelsHidden()
+                            }
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 10)
+                            if curated.id != CuratedExtensions.all.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                    .background(.background.secondary)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+
+                settingsDivider
+
+                // Custom extensions behind a disclosure group
+                DisclosureGroup("Custom Extensions") {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Add third-party extensions by pasting a Chrome Web Store URL. These extensions can access all browsing data within the session.")
                         .settingDescription()
@@ -972,6 +1014,7 @@ struct ProfileSettingsView: View {
                 }
                 .padding(.top, 8)
             }
+            } // end if extensionsEnabled
         }
     }
 

--- a/Sources/Browser/ProfileSettingsView.swift
+++ b/Sources/Browser/ProfileSettingsView.swift
@@ -19,6 +19,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case hostIsolation = "Host Isolation"
     case network = "Network Isolation"
     case privacy = "Privacy & Safety"
+    case extensions = "Extensions"
     case vpnAds = "VPN & Ads"
     case enterprise = "Enterprise"
     case advanced = "Advanced"
@@ -33,6 +34,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .fileTransfer: "arrow.up.arrow.down"
         case .hostIsolation: "macwindow.on.rectangle"
         case .privacy: "lock.shield.fill"
+        case .extensions: "puzzlepiece.extension.fill"
         case .network: "network"
         case .vpnAds: "shield.fill"
         case .enterprise: "building.2.fill"
@@ -48,6 +50,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .fileTransfer: .cyan
         case .hostIsolation: .teal
         case .privacy: .blue
+        case .extensions: .mint
         case .network: .indigo
         case .vpnAds: .green
         case .enterprise: .purple
@@ -117,6 +120,10 @@ struct ProfileSettingsView: View {
     @State private var vtKeyStatus: VTKeyStatus?
     @State private var proxyHostError: String?
     @State private var proxyHostChecking = false
+    @State private var showExtensionURLField = false
+    @State private var extensionURL = ""
+    @State private var extensionImportError: String?
+    @State private var extensionDownloading = false
 
     // IKEv2 keychain-backed secrets (not stored in profile JSON)
     @State private var ikev2Password: String = ""
@@ -282,6 +289,7 @@ struct ProfileSettingsView: View {
         case .fileTransfer: fileTransferView
         case .hostIsolation: hostIsolationView
         case .privacy: privacyView
+        case .extensions: extensionsView
         case .network: networkView
         case .vpnAds: vpnAdsView
         case .enterprise: enterpriseView
@@ -813,6 +821,207 @@ struct ProfileSettingsView: View {
         }
     }
 
+    // MARK: - Extensions
+
+    private var extensionsView: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            sectionHeader("Extensions", subtitle: "Add browser extensions to this profile")
+
+            // Curated extensions
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Recommended").font(.headline)
+                Text("Popular privacy and security extensions. Toggling an extension will download it on first use.")
+                    .settingDescription()
+
+                VStack(spacing: 0) {
+                    ForEach(CuratedExtensions.all) { curated in
+                        let isEnabled = draft.settings.userExtensions.contains { $0.extensionID == curated.extensionID && $0.enabled }
+                        HStack {
+                            Image(systemName: "puzzlepiece.extension.fill")
+                                .foregroundStyle(.secondary)
+                            Text(curated.name)
+                            Spacer()
+                            Toggle("", isOn: Binding(
+                                get: { isEnabled },
+                                set: { on in
+                                    if on {
+                                        if let idx = draft.settings.userExtensions.firstIndex(where: { $0.extensionID == curated.extensionID }) {
+                                            draft.settings.userExtensions[idx].enabled = true
+                                        } else {
+                                            var ext = curated
+                                            ext.enabled = true
+                                            draft.settings.userExtensions.append(ext)
+                                            Task { try? await ExtensionCache.shared.download(extensionID: curated.extensionID) }
+                                        }
+                                    } else {
+                                        if let idx = draft.settings.userExtensions.firstIndex(where: { $0.extensionID == curated.extensionID }) {
+                                            draft.settings.userExtensions[idx].enabled = false
+                                        }
+                                    }
+                                }
+                            ))
+                            .toggleStyle(.switch)
+                            .labelsHidden()
+                        }
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 10)
+                        if curated.id != CuratedExtensions.all.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+                .background(.background.secondary)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+
+            settingsDivider
+
+            // Custom extensions behind a disclosure group
+            DisclosureGroup("Custom Extensions") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Add third-party extensions by pasting a Chrome Web Store URL. These extensions can access all browsing data within the session.")
+                        .settingDescription()
+
+                    Label {
+                        Text("Custom extensions are not vetted by Bromure. Only install extensions you trust.")
+                            .font(.callout)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.yellow)
+                    }
+                    .padding(10)
+                    .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+
+                    let customExtensions = draft.settings.userExtensions.filter { !$0.curated }
+                    if !customExtensions.isEmpty {
+                        VStack(spacing: 0) {
+                            ForEach(customExtensions) { ext in
+                                HStack {
+                                    Image(systemName: "puzzlepiece.extension")
+                                        .foregroundStyle(.secondary)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(ext.name).lineLimit(1)
+                                        Text(ext.extensionID)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                    Spacer()
+                                    Toggle("", isOn: Binding(
+                                        get: { ext.enabled },
+                                        set: { on in
+                                            if let idx = draft.settings.userExtensions.firstIndex(where: { $0.id == ext.id }) {
+                                                draft.settings.userExtensions[idx].enabled = on
+                                            }
+                                        }
+                                    ))
+                                    .toggleStyle(.switch)
+                                    .labelsHidden()
+                                    Button(role: .destructive) {
+                                        draft.settings.userExtensions.removeAll { $0.id == ext.id }
+                                    } label: {
+                                        Image(systemName: "trash")
+                                            .foregroundStyle(.red)
+                                    }
+                                    .buttonStyle(.borderless)
+                                }
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 10)
+                                if ext.id != customExtensions.last?.id {
+                                    Divider()
+                                }
+                            }
+                        }
+                        .background(.background.secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+
+                    if showExtensionURLField {
+                        HStack {
+                            TextField("Chrome Web Store URL", text: $extensionURL)
+                                .textFieldStyle(.roundedBorder)
+                                .onSubmit { addExtensionFromURL() }
+                            Button("Add") { addExtensionFromURL() }
+                                .disabled(extensionURL.isEmpty || extensionDownloading)
+                            Button("Cancel") {
+                                showExtensionURLField = false
+                                extensionURL = ""
+                                extensionImportError = nil
+                            }
+                        }
+                        if extensionDownloading {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+
+                    if !showExtensionURLField {
+                        Button {
+                            showExtensionURLField = true
+                        } label: {
+                            Label("Add Extension\u{2026}", systemImage: "plus.circle")
+                        }
+                        .controlSize(.small)
+                    }
+
+                    if let err = extensionImportError {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+                .padding(.top, 8)
+            }
+        }
+    }
+
+    private func addExtensionFromURL() {
+        extensionImportError = nil
+        guard let extID = Self.parseExtensionID(from: extensionURL) else {
+            extensionImportError = "Invalid Chrome Web Store URL. Expected format: chromewebstore.google.com/detail/.../EXTENSION_ID"
+            return
+        }
+        if draft.settings.userExtensions.contains(where: { $0.extensionID == extID }) {
+            extensionImportError = "This extension is already added."
+            return
+        }
+        extensionDownloading = true
+        Task {
+            do {
+                _ = try await ExtensionCache.shared.download(extensionID: extID)
+                let name = (try? await ExtensionCache.shared.extractName(for: extID)) ?? extID
+                await MainActor.run {
+                    draft.settings.userExtensions.append(
+                        UserExtension(name: name, extensionID: extID, curated: false)
+                    )
+                    extensionURL = ""
+                    showExtensionURLField = false
+                    extensionDownloading = false
+                }
+            } catch {
+                await MainActor.run {
+                    extensionImportError = "Failed to download extension: \(error.localizedDescription)"
+                    extensionDownloading = false
+                }
+            }
+        }
+    }
+
+    static func parseExtensionID(from urlString: String) -> String? {
+        let pattern = #"chromewebstore\.google\.com/detail/[^/]+/([a-p]{32})"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: urlString, range: NSRange(urlString.startIndex..., in: urlString)),
+              let range = Range(match.range(at: 1), in: urlString) else {
+            // Also accept a bare 32-char extension ID
+            let bare = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+            if bare.count == 32, bare.allSatisfy({ $0 >= "a" && $0 <= "p" }) {
+                return bare
+            }
+            return nil
+        }
+        return String(urlString[range])
+    }
+
     // MARK: - Network Isolation
 
     private var networkView: some View {
@@ -1327,6 +1536,7 @@ struct ProfileSettingsView: View {
                         .settingDescription()
                 }
             }
+
         }
     }
 

--- a/Sources/SandboxEngine/CuratedExtensions.swift
+++ b/Sources/SandboxEngine/CuratedExtensions.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public enum CuratedExtensions {
+    public static let all: [UserExtension] = [
+        UserExtension(name: "uBlock Origin Lite", extensionID: "ddkjiahejlhfcafbddmgiahcphecmpfh", curated: true),
+        UserExtension(name: "Bitwarden", extensionID: "nngceckbapebfimnlniiiahkandclblb", curated: true),
+        UserExtension(name: "1Password", extensionID: "aeblfdkhhhdcdjpifhhbdiojplfjncoa", curated: true),
+        UserExtension(name: "Privacy Badger", extensionID: "pkehgijcmpdhfbdbbnkijodmdjhbjlgp", curated: true),
+    ]
+}

--- a/Sources/SandboxEngine/CuratedExtensions.swift
+++ b/Sources/SandboxEngine/CuratedExtensions.swift
@@ -3,8 +3,6 @@ import Foundation
 public enum CuratedExtensions {
     public static let all: [UserExtension] = [
         UserExtension(name: "uBlock Origin Lite", extensionID: "ddkjiahejlhfcafbddmgiahcphecmpfh", curated: true),
-        UserExtension(name: "Bitwarden", extensionID: "nngceckbapebfimnlniiiahkandclblb", curated: true),
-        UserExtension(name: "1Password", extensionID: "aeblfdkhhhdcdjpifhhbdiojplfjncoa", curated: true),
         UserExtension(name: "Privacy Badger", extensionID: "pkehgijcmpdhfbdbbnkijodmdjhbjlgp", curated: true),
     ]
 }

--- a/Sources/SandboxEngine/ExtensionCache.swift
+++ b/Sources/SandboxEngine/ExtensionCache.swift
@@ -3,6 +3,10 @@ import Foundation
 public actor ExtensionCache {
     public static let shared = ExtensionCache()
 
+    public static func isValidExtensionID(_ id: String) -> Bool {
+        id.count == 32 && id.allSatisfy { $0 >= "a" && $0 <= "p" }
+    }
+
     private var cacheDir: URL {
         VMConfig.defaultStorageDirectory.appendingPathComponent("extensions", isDirectory: true)
     }
@@ -16,6 +20,9 @@ public actor ExtensionCache {
     }
 
     public func download(extensionID: String) async throws -> URL {
+        guard Self.isValidExtensionID(extensionID) else {
+            throw ExtensionCacheError.invalidExtensionID
+        }
         let dir = extensionDir(for: extensionID)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
@@ -92,7 +99,7 @@ public actor ExtensionCache {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        process.arguments = ["-o", "-q", zipFile.path, "manifest.json", "-d", tempDir.path]
+        process.arguments = ["-o", "-j", "-q", zipFile.path, "manifest.json", "-d", tempDir.path]
         try process.run()
         process.waitUntilExit()
 

--- a/Sources/SandboxEngine/ExtensionCache.swift
+++ b/Sources/SandboxEngine/ExtensionCache.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+public actor ExtensionCache {
+    public static let shared = ExtensionCache()
+
+    private var cacheDir: URL {
+        VMConfig.defaultStorageDirectory.appendingPathComponent("extensions", isDirectory: true)
+    }
+
+    private func extensionDir(for extensionID: String) -> URL {
+        cacheDir.appendingPathComponent(extensionID, isDirectory: true)
+    }
+
+    private func crxFile(for extensionID: String) -> URL {
+        extensionDir(for: extensionID).appendingPathComponent("extension.crx")
+    }
+
+    public func download(extensionID: String) async throws -> URL {
+        let dir = extensionDir(for: extensionID)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let urlString = "https://clients2.google.com/service/update2/crx"
+            + "?response=redirect&prodversion=130.0&acceptformat=crx3"
+            + "&x=id%3D\(extensionID)%26uc"
+        guard let url = URL(string: urlString) else {
+            throw ExtensionCacheError.invalidExtensionID
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw ExtensionCacheError.downloadFailed
+        }
+        guard !data.isEmpty else {
+            throw ExtensionCacheError.downloadFailed
+        }
+
+        let dest = crxFile(for: extensionID)
+        try data.write(to: dest, options: .atomic)
+        return dest
+    }
+
+    public nonisolated func cachedPathSync(for extensionID: String) -> URL? {
+        let path = VMConfig.defaultStorageDirectory
+            .appendingPathComponent("extensions", isDirectory: true)
+            .appendingPathComponent(extensionID, isDirectory: true)
+            .appendingPathComponent("extension.crx")
+        return FileManager.default.fileExists(atPath: path.path) ? path : nil
+    }
+
+    public func cachedPath(for extensionID: String) -> URL? {
+        let path = crxFile(for: extensionID)
+        return FileManager.default.fileExists(atPath: path.path) ? path : nil
+    }
+
+    public func extractName(for extensionID: String) throws -> String? {
+        guard let crxURL = cachedPath(for: extensionID) else { return nil }
+        let crxData = try Data(contentsOf: crxURL)
+        let zipData = try Self.extractZipFromCRX(crxData)
+        return try Self.readNameFromManifest(zipData: zipData)
+    }
+
+    public func clearCache(for extensionID: String) throws {
+        let dir = extensionDir(for: extensionID)
+        if FileManager.default.fileExists(atPath: dir.path) {
+            try FileManager.default.removeItem(at: dir)
+        }
+    }
+
+    // MARK: - CRX parsing
+
+    static func extractZipFromCRX(_ data: Data) throws -> Data {
+        guard data.count > 16 else { throw ExtensionCacheError.invalidCRX }
+        let magic = data[data.startIndex..<data.startIndex + 4]
+        if magic == Data([0x43, 0x72, 0x32, 0x34]) {  // "Cr24"
+            let headerLen = data.withUnsafeBytes { buf in
+                buf.load(fromByteOffset: 8, as: UInt32.self).littleEndian
+            }
+            let zipStart = 12 + Int(headerLen)
+            guard zipStart < data.count else { throw ExtensionCacheError.invalidCRX }
+            return data[zipStart...]  as Data
+        }
+        return data
+    }
+
+    static func readNameFromManifest(zipData: Data) throws -> String? {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let zipFile = tempDir.appendingPathComponent("ext.zip")
+        try zipData.write(to: zipFile)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-o", "-q", zipFile.path, "manifest.json", "-d", tempDir.path]
+        try process.run()
+        process.waitUntilExit()
+
+        let manifestURL = tempDir.appendingPathComponent("manifest.json")
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else { return nil }
+        let manifestData = try Data(contentsOf: manifestURL)
+        guard let json = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any] else { return nil }
+        return json["name"] as? String
+    }
+}
+
+public enum ExtensionCacheError: Error, LocalizedError {
+    case invalidExtensionID
+    case downloadFailed
+    case invalidCRX
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidExtensionID: "Invalid extension ID"
+        case .downloadFailed: "Failed to download extension"
+        case .invalidCRX: "Invalid CRX file format"
+        }
+    }
+}

--- a/Sources/SandboxEngine/Profile.swift
+++ b/Sources/SandboxEngine/Profile.swift
@@ -289,6 +289,7 @@ public struct ProfileSettings: Codable, Equatable {
     public var rootCAs: [CustomRootCA] = []
 
     // User extensions
+    public var extensionsEnabled: Bool = false
     public var userExtensions: [UserExtension] = []
 
     // Input
@@ -340,7 +341,7 @@ public struct ProfileSettings: Codable, Equatable {
         case isolateFromLAN, restrictPorts, allowedPorts, networkInterface
         case enableAudio, audioVolume, enableWebcam, webcamQuality, enableMicrophone
         case webcamDeviceID, microphoneDeviceID, speakerDeviceID, webcamEffects
-        case rootCAs, userExtensions, matchKeyboardLayout, locale, allowAutomation
+        case rootCAs, extensionsEnabled, userExtensions, matchKeyboardLayout, locale, allowAutomation
         case traceLevel, traceAutoStart, persistent, encryptOnDisk
         case nativeChrome, allowPrinting
     }
@@ -411,6 +412,7 @@ public struct ProfileSettings: Codable, Equatable {
         speakerDeviceID = try c.decodeIfPresent(String.self, forKey: .speakerDeviceID)
         webcamEffects = try c.decodeIfPresent(WebcamEffects.self, forKey: .webcamEffects) ?? defaults.webcamEffects
         rootCAs = try c.decodeIfPresent([CustomRootCA].self, forKey: .rootCAs) ?? defaults.rootCAs
+        extensionsEnabled = try c.decodeIfPresent(Bool.self, forKey: .extensionsEnabled) ?? defaults.extensionsEnabled
         userExtensions = try c.decodeIfPresent([UserExtension].self, forKey: .userExtensions) ?? defaults.userExtensions
         matchKeyboardLayout = try c.decodeIfPresent(Bool.self, forKey: .matchKeyboardLayout) ?? defaults.matchKeyboardLayout
         locale = try c.decodeIfPresent(String.self, forKey: .locale)
@@ -479,6 +481,7 @@ public struct ProfileSettings: Codable, Equatable {
         try c.encodeIfPresent(speakerDeviceID, forKey: .speakerDeviceID)
         try c.encode(webcamEffects, forKey: .webcamEffects)
         try c.encode(rootCAs, forKey: .rootCAs)
+        try c.encode(extensionsEnabled, forKey: .extensionsEnabled)
         try c.encode(userExtensions, forKey: .userExtensions)
         try c.encode(matchKeyboardLayout, forKey: .matchKeyboardLayout)
         try c.encodeIfPresent(locale, forKey: .locale)
@@ -581,7 +584,7 @@ public struct ProfileSettings: Codable, Equatable {
             matchKeyboardLayout: matchKeyboardLayout,
             extraKernelOptions: defaults.string(forKey: "vm.extraKernelOptions") ?? VMConfig.defaultExtraKernelOptions,
             locale: locale,
-            userExtensionIDs: userExtensions.filter(\.enabled).map(\.extensionID)
+            userExtensionIDs: extensionsEnabled ? userExtensions.filter(\.enabled).map(\.extensionID) : []
         )
     }
 

--- a/Sources/SandboxEngine/Profile.swift
+++ b/Sources/SandboxEngine/Profile.swift
@@ -86,6 +86,20 @@ public struct CustomRootCA: Codable, Equatable, Identifiable {
     }
 }
 
+public struct UserExtension: Codable, Equatable, Identifiable {
+    public var id = UUID()
+    public var name: String
+    public var extensionID: String
+    public var enabled: Bool = true
+    public var curated: Bool
+
+    public init(name: String, extensionID: String, curated: Bool = false) {
+        self.name = name
+        self.extensionID = extensionID
+        self.curated = curated
+    }
+}
+
 /// VPN mode for the browser session.
 public enum VPNMode: String, Codable, CaseIterable, Equatable, Sendable {
     /// No VPN — direct connection.
@@ -274,6 +288,9 @@ public struct ProfileSettings: Codable, Equatable {
     // Certificates
     public var rootCAs: [CustomRootCA] = []
 
+    // User extensions
+    public var userExtensions: [UserExtension] = []
+
     // Input
     public var matchKeyboardLayout: Bool = true  // dynamically sync host keyboard layout
 
@@ -323,7 +340,7 @@ public struct ProfileSettings: Codable, Equatable {
         case isolateFromLAN, restrictPorts, allowedPorts, networkInterface
         case enableAudio, audioVolume, enableWebcam, webcamQuality, enableMicrophone
         case webcamDeviceID, microphoneDeviceID, speakerDeviceID, webcamEffects
-        case rootCAs, matchKeyboardLayout, locale, allowAutomation
+        case rootCAs, userExtensions, matchKeyboardLayout, locale, allowAutomation
         case traceLevel, traceAutoStart, persistent, encryptOnDisk
         case nativeChrome, allowPrinting
     }
@@ -394,6 +411,7 @@ public struct ProfileSettings: Codable, Equatable {
         speakerDeviceID = try c.decodeIfPresent(String.self, forKey: .speakerDeviceID)
         webcamEffects = try c.decodeIfPresent(WebcamEffects.self, forKey: .webcamEffects) ?? defaults.webcamEffects
         rootCAs = try c.decodeIfPresent([CustomRootCA].self, forKey: .rootCAs) ?? defaults.rootCAs
+        userExtensions = try c.decodeIfPresent([UserExtension].self, forKey: .userExtensions) ?? defaults.userExtensions
         matchKeyboardLayout = try c.decodeIfPresent(Bool.self, forKey: .matchKeyboardLayout) ?? defaults.matchKeyboardLayout
         locale = try c.decodeIfPresent(String.self, forKey: .locale)
         allowAutomation = try c.decodeIfPresent(Bool.self, forKey: .allowAutomation) ?? defaults.allowAutomation
@@ -461,6 +479,7 @@ public struct ProfileSettings: Codable, Equatable {
         try c.encodeIfPresent(speakerDeviceID, forKey: .speakerDeviceID)
         try c.encode(webcamEffects, forKey: .webcamEffects)
         try c.encode(rootCAs, forKey: .rootCAs)
+        try c.encode(userExtensions, forKey: .userExtensions)
         try c.encode(matchKeyboardLayout, forKey: .matchKeyboardLayout)
         try c.encodeIfPresent(locale, forKey: .locale)
         try c.encode(allowAutomation, forKey: .allowAutomation)
@@ -561,7 +580,8 @@ public struct ProfileSettings: Codable, Equatable {
             traceLevel: traceLevel,
             matchKeyboardLayout: matchKeyboardLayout,
             extraKernelOptions: defaults.string(forKey: "vm.extraKernelOptions") ?? VMConfig.defaultExtraKernelOptions,
-            locale: locale
+            locale: locale,
+            userExtensionIDs: userExtensions.filter(\.enabled).map(\.extensionID)
         )
     }
 

--- a/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
+++ b/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
@@ -771,7 +771,7 @@ def write_dynamic_policy(cfg):
     ext_ids = [eid for eid in cfg.get("userExtensionIDs", []) if _VALID_EXT_ID.match(eid)]
     if ext_ids:
         policy["ExtensionsToolbarAccessEnabled"] = True
-        ext_settings = {"*": {"installation_mode": "blocked"}}
+        ext_settings = {}
         for ext_id in ext_ids:
             ext_settings[ext_id] = {
                 "installation_mode": "force_installed",

--- a/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
+++ b/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
@@ -13,6 +13,7 @@ This replaces serial-based config delivery for lower latency.
 
 import json
 import os
+import re
 import socket
 import struct
 import subprocess

--- a/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
+++ b/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
@@ -250,6 +250,73 @@ def sh_escape(s):
     return "'" + str(s).replace("'", "'\\''") + "'"
 
 
+def download_user_extensions(cfg):
+    """Download and unpack user extensions by ID from Google's CRX endpoint."""
+    ext_ids = cfg.get("userExtensionIDs", [])
+    if not ext_ids:
+        return []
+
+    import io
+    import urllib.request
+    import zipfile
+
+    ext_dir = "/tmp/bromure/user-extensions"
+    os.makedirs(ext_dir, exist_ok=True)
+    paths = []
+
+    # Route through local squid proxy if running (all non-custom-proxy
+    # profiles use squid on 127.0.0.1:3128 for outbound traffic).
+    proxy_handler = urllib.request.ProxyHandler({
+        "http": "http://127.0.0.1:3128",
+        "https": "http://127.0.0.1:3128",
+    })
+    opener = urllib.request.build_opener(proxy_handler)
+
+    for ext_id in ext_ids:
+        if not ext_id:
+            continue
+        dest = os.path.join(ext_dir, ext_id)
+        manifest = os.path.join(dest, "manifest.json")
+        if os.path.isfile(manifest):
+            paths.append(dest)
+            print(f"config-agent: user extension {ext_id} already unpacked")
+            continue
+        try:
+            url = (
+                "https://clients2.google.com/service/update2/crx"
+                f"?response=redirect&prodversion=130.0&acceptformat=crx3"
+                f"&x=id%3D{ext_id}%26uc"
+            )
+            print(f"config-agent: downloading extension {ext_id}...")
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+            # Try proxy first, fall back to direct
+            try:
+                with opener.open(req, timeout=30) as resp:
+                    crx_data = resp.read()
+            except Exception:
+                print(f"config-agent: proxy failed, trying direct for {ext_id}...")
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    crx_data = resp.read()
+            # CRX3: magic "Cr24" (4) + version (4) + header_len (4, LE) + header + ZIP
+            if crx_data[:4] == b"Cr24":
+                header_len = int.from_bytes(crx_data[8:12], "little")
+                zip_data = crx_data[12 + header_len:]
+            else:
+                zip_data = crx_data
+            os.makedirs(dest, exist_ok=True)
+            with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+                zf.extractall(dest)
+            if os.path.isfile(manifest):
+                paths.append(dest)
+                print(f"config-agent: installed user extension {ext_id}")
+            else:
+                print(f"config-agent: WARNING: no manifest.json in extension {ext_id}")
+        except Exception as e:
+            print(f"config-agent: WARNING: failed to download extension {ext_id}: {e}")
+
+    return paths
+
+
 def write_chrome_env(cfg):
     """Build and write the chrome-env file."""
     env_file = "/tmp/bromure/chrome-env"
@@ -343,10 +410,11 @@ def write_chrome_env(cfg):
         extensions.append("/opt/bromure/extensions/corporate-guard")
     if extensions:
         extra_flags.append(f"--load-extension={','.join(extensions)}")
-        # Only allow our bundled extensions — disable every other extension
-        # Chromium might try to load (policy-pushed, user-installed in a
-        # persistent profile, etc.).
-        extra_flags.append(f"--disable-extensions-except={','.join(extensions)}")
+        # Only restrict extensions when no user extensions are configured.
+        # Policy-installed user extensions need unrestricted loading;
+        # the ExtensionSettings policy controls what gets installed.
+        if not cfg.get("userExtensionIDs"):
+            extra_flags.append(f"--disable-extensions-except={','.join(extensions)}")
 
     profile_dir = cfg.get("profileDir")
     if profile_dir:
@@ -762,6 +830,21 @@ def write_dynamic_policy(cfg):
         policy["AutofillCreditCardEnabled"] = False
         policy["CredentialProviderPromoEnabled"] = False
 
+    # When user extensions are configured, use ExtensionSettings policy
+    # to force-install them. Chrome handles the download, installation,
+    # and DNR rule compilation — no unpacking needed.
+    ext_ids = cfg.get("userExtensionIDs", [])
+    if ext_ids:
+        policy["ExtensionsToolbarAccessEnabled"] = True
+        ext_settings = {}
+        for ext_id in ext_ids:
+            ext_settings[ext_id] = {
+                "installation_mode": "force_installed",
+                "update_url": "https://clients2.google.com/service/update2/crx",
+                "toolbar_pin": "force_pinned",
+            }
+        policy["ExtensionSettings"] = ext_settings
+
     policy_path = "/etc/chromium/policies/managed/session.json"
     os.makedirs(os.path.dirname(policy_path), exist_ok=True)
     with open(policy_path, "w") as f:
@@ -1026,7 +1109,7 @@ def main():
     # branch is correct from first page load.
     write_file_picker_policy(cfg)
 
-    # Write chrome-env
+    # Write chrome-env (user extensions added after network services start)
     write_chrome_env(cfg)
 
     # Write dynamic Chrome policy (media capture, WebRTC)

--- a/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
+++ b/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
@@ -250,73 +250,6 @@ def sh_escape(s):
     return "'" + str(s).replace("'", "'\\''") + "'"
 
 
-def download_user_extensions(cfg):
-    """Download and unpack user extensions by ID from Google's CRX endpoint."""
-    ext_ids = cfg.get("userExtensionIDs", [])
-    if not ext_ids:
-        return []
-
-    import io
-    import urllib.request
-    import zipfile
-
-    ext_dir = "/tmp/bromure/user-extensions"
-    os.makedirs(ext_dir, exist_ok=True)
-    paths = []
-
-    # Route through local squid proxy if running (all non-custom-proxy
-    # profiles use squid on 127.0.0.1:3128 for outbound traffic).
-    proxy_handler = urllib.request.ProxyHandler({
-        "http": "http://127.0.0.1:3128",
-        "https": "http://127.0.0.1:3128",
-    })
-    opener = urllib.request.build_opener(proxy_handler)
-
-    for ext_id in ext_ids:
-        if not ext_id:
-            continue
-        dest = os.path.join(ext_dir, ext_id)
-        manifest = os.path.join(dest, "manifest.json")
-        if os.path.isfile(manifest):
-            paths.append(dest)
-            print(f"config-agent: user extension {ext_id} already unpacked")
-            continue
-        try:
-            url = (
-                "https://clients2.google.com/service/update2/crx"
-                f"?response=redirect&prodversion=130.0&acceptformat=crx3"
-                f"&x=id%3D{ext_id}%26uc"
-            )
-            print(f"config-agent: downloading extension {ext_id}...")
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-            # Try proxy first, fall back to direct
-            try:
-                with opener.open(req, timeout=30) as resp:
-                    crx_data = resp.read()
-            except Exception:
-                print(f"config-agent: proxy failed, trying direct for {ext_id}...")
-                with urllib.request.urlopen(req, timeout=30) as resp:
-                    crx_data = resp.read()
-            # CRX3: magic "Cr24" (4) + version (4) + header_len (4, LE) + header + ZIP
-            if crx_data[:4] == b"Cr24":
-                header_len = int.from_bytes(crx_data[8:12], "little")
-                zip_data = crx_data[12 + header_len:]
-            else:
-                zip_data = crx_data
-            os.makedirs(dest, exist_ok=True)
-            with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
-                zf.extractall(dest)
-            if os.path.isfile(manifest):
-                paths.append(dest)
-                print(f"config-agent: installed user extension {ext_id}")
-            else:
-                print(f"config-agent: WARNING: no manifest.json in extension {ext_id}")
-        except Exception as e:
-            print(f"config-agent: WARNING: failed to download extension {ext_id}: {e}")
-
-    return paths
-
-
 def write_chrome_env(cfg):
     """Build and write the chrome-env file."""
     env_file = "/tmp/bromure/chrome-env"
@@ -1109,7 +1042,7 @@ def main():
     # branch is correct from first page load.
     write_file_picker_policy(cfg)
 
-    # Write chrome-env (user extensions added after network services start)
+    # Write chrome-env
     write_chrome_env(cfg)
 
     # Write dynamic Chrome policy (media capture, WebRTC)

--- a/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
+++ b/Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py
@@ -766,10 +766,11 @@ def write_dynamic_policy(cfg):
     # When user extensions are configured, use ExtensionSettings policy
     # to force-install them. Chrome handles the download, installation,
     # and DNR rule compilation — no unpacking needed.
-    ext_ids = cfg.get("userExtensionIDs", [])
+    _VALID_EXT_ID = re.compile(r"^[a-p]{32}$")
+    ext_ids = [eid for eid in cfg.get("userExtensionIDs", []) if _VALID_EXT_ID.match(eid)]
     if ext_ids:
         policy["ExtensionsToolbarAccessEnabled"] = True
-        ext_settings = {}
+        ext_settings = {"*": {"installation_mode": "blocked"}}
         for ext_id in ext_ids:
             ext_settings[ext_id] = {
                 "installation_mode": "force_installed",

--- a/Sources/SandboxEngine/VMConfig.swift
+++ b/Sources/SandboxEngine/VMConfig.swift
@@ -262,6 +262,9 @@ public struct VMConfig {
     /// Default includes module loading and M4 CPU workarounds.
     public var extraKernelOptions: String
 
+    /// Chrome Web Store extension IDs to download and load in the guest.
+    public var userExtensionIDs: [String]
+
     public init(
         cpuCount: Int? = nil,
         memorySize: UInt64 = 4 * 1024 * 1024 * 1024,
@@ -329,7 +332,8 @@ public struct VMConfig {
         extraKernelOptions: String = "arm64.nosme",
         keyboardLayout: String? = nil,
         naturalScrolling: Bool? = nil,
-        locale: String? = nil
+        locale: String? = nil,
+        userExtensionIDs: [String] = []
     ) {
         let memGB = Int(memorySize / (1024 * 1024 * 1024))
         self.cpuCount = cpuCount ?? min(max(2, memGB * 2), ProcessInfo.processInfo.processorCount)
@@ -399,6 +403,7 @@ public struct VMConfig {
         self.keyboardLayout = keyboardLayout ?? VMConfig.detectKeyboardLayout()
         self.naturalScrolling = naturalScrolling ?? VMConfig.detectNaturalScrolling()
         self.locale = locale ?? VMConfig.detectLocale()
+        self.userExtensionIDs = userExtensionIDs
     }
 
     /// Mapping from macOS keyboard layout names (lowercased, without `com.apple.keylayout.` prefix)

--- a/Sources/SandboxEngine/VMPool.swift
+++ b/Sources/SandboxEngine/VMPool.swift
@@ -585,6 +585,10 @@ public final class VMPool {
         }
         cfg["locale"] = config.locale
 
+        if !config.userExtensionIDs.isEmpty {
+            cfg["userExtensionIDs"] = config.userExtensionIDs
+        }
+
         // Display scale: read from UserDefaults so changing 1x/2x doesn't require image rebuild
         let displayScale = UserDefaults.standard.object(forKey: "vm.displayScale") as? Int ?? VMConfig.detectDisplayScale()
         cfg["displayScale"] = displayScale

--- a/Sources/SandboxEngine/VMPool.swift
+++ b/Sources/SandboxEngine/VMPool.swift
@@ -585,8 +585,9 @@ public final class VMPool {
         }
         cfg["locale"] = config.locale
 
-        if !config.userExtensionIDs.isEmpty {
-            cfg["userExtensionIDs"] = config.userExtensionIDs
+        let validExtIDs = config.userExtensionIDs.filter { ExtensionCache.isValidExtensionID($0) }
+        if !validExtIDs.isEmpty {
+            cfg["userExtensionIDs"] = validExtIDs
         }
 
         // Display scale: read from UserDefaults so changing 1x/2x doesn't require image rebuild

--- a/Tests/SafariSandboxTests/SafariSandboxTests.swift
+++ b/Tests/SafariSandboxTests/SafariSandboxTests.swift
@@ -1577,3 +1577,111 @@ struct VPNEndpointPortTests {
         #expect(VMPool.vpnEndpointPorts(for: config(vpnMode: .wireGuard, wireGuardConfig: conf)) == [9999])
     }
 }
+
+// MARK: - UserExtension Tests
+
+@Suite("UserExtension")
+struct UserExtensionTests {
+    @Test("Codable roundtrip preserves all fields")
+    func codableRoundtrip() throws {
+        let ext = UserExtension(name: "Test Ext", extensionID: "abcdefghijklmnopabcdefghijklmnop", curated: true)
+        let data = try JSONEncoder().encode(ext)
+        let decoded = try JSONDecoder().decode(UserExtension.self, from: data)
+        #expect(decoded.name == ext.name)
+        #expect(decoded.extensionID == ext.extensionID)
+        #expect(decoded.enabled == ext.enabled)
+        #expect(decoded.curated == ext.curated)
+    }
+
+    @Test("Default enabled is true")
+    func defaultEnabled() {
+        let ext = UserExtension(name: "Test", extensionID: "abcdefghijklmnopabcdefghijklmnop")
+        #expect(ext.enabled == true)
+        #expect(ext.curated == false)
+    }
+}
+
+// MARK: - ProfileSettings UserExtensions Tests
+
+@Suite("ProfileSettings UserExtensions")
+struct ProfileSettingsUserExtensionsTests {
+    @Test("Backward compatibility: old profiles without userExtensions decode cleanly")
+    func backwardCompatibility() throws {
+        let json = """
+        {
+            "homePage": "https://example.com",
+            "enableGPU": true,
+            "enableWebGL": false,
+            "enableZeroCopy": true,
+            "enableSmoothScrolling": true,
+            "enableAdBlocking": false,
+            "enableClipboardSharing": false,
+            "canUpload": false,
+            "canDownload": false,
+            "phishingWarning": false,
+            "blockMalwareSites": false,
+            "enableAudio": true,
+            "audioVolume": 100
+        }
+        """
+        let settings = try JSONDecoder().decode(ProfileSettings.self, from: Data(json.utf8))
+        #expect(settings.userExtensions.isEmpty)
+    }
+
+    @Test("Roundtrip with user extensions")
+    func roundtripWithExtensions() throws {
+        var settings = ProfileSettings()
+        settings.userExtensions = [
+            UserExtension(name: "uBlock Origin Lite", extensionID: "ddkjiahejlhfcafbddmgiahcphecmpfh", curated: true),
+            UserExtension(name: "Custom Ext", extensionID: "abcdefghijklmnopabcdefghijklmnop", curated: false),
+        ]
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(ProfileSettings.self, from: data)
+        #expect(decoded.userExtensions.count == 2)
+        #expect(decoded.userExtensions[0].name == "uBlock Origin Lite")
+        #expect(decoded.userExtensions[1].curated == false)
+    }
+
+    @Test("toVMConfig maps only enabled extensions")
+    func toVMConfigFiltersDisabled() {
+        var settings = ProfileSettings()
+        var ext1 = UserExtension(name: "Enabled", extensionID: "aaaaaaaaaaaaaaapaaaaaaaaaaaaaaap", curated: true)
+        ext1.enabled = true
+        var ext2 = UserExtension(name: "Disabled", extensionID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", curated: false)
+        ext2.enabled = false
+        settings.userExtensions = [ext1, ext2]
+        let config = settings.toVMConfig()
+        #expect(config.userExtensionIDs == ["aaaaaaaaaaaaaaapaaaaaaaaaaaaaaap"])
+    }
+}
+
+// MARK: - CuratedExtensions Tests
+
+@Suite("CuratedExtensions")
+struct CuratedExtensionsTests {
+    @Test("Curated list is non-empty")
+    func nonEmpty() {
+        #expect(!CuratedExtensions.all.isEmpty)
+    }
+
+    @Test("All curated extensions have valid 32-char IDs")
+    func validIDs() {
+        for ext in CuratedExtensions.all {
+            #expect(ext.extensionID.count == 32)
+            #expect(ext.extensionID.allSatisfy { $0 >= "a" && $0 <= "p" })
+        }
+    }
+
+    @Test("All curated extensions are marked as curated")
+    func markedCurated() {
+        for ext in CuratedExtensions.all {
+            #expect(ext.curated == true)
+        }
+    }
+
+    @Test("No duplicate extension IDs")
+    func noDuplicates() {
+        let ids = CuratedExtensions.all.map(\.extensionID)
+        #expect(Set(ids).count == ids.count)
+    }
+}

--- a/Tests/SafariSandboxTests/SafariSandboxTests.swift
+++ b/Tests/SafariSandboxTests/SafariSandboxTests.swift
@@ -1645,6 +1645,7 @@ struct ProfileSettingsUserExtensionsTests {
     @Test("toVMConfig maps only enabled extensions")
     func toVMConfigFiltersDisabled() {
         var settings = ProfileSettings()
+        settings.extensionsEnabled = true
         var ext1 = UserExtension(name: "Enabled", extensionID: "aaaaaaaaaaaaaaapaaaaaaaaaaaaaaap", curated: true)
         ext1.enabled = true
         var ext2 = UserExtension(name: "Disabled", extensionID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", curated: false)


### PR DESCRIPTION
## Summary

Adds per-profile browser extension support to Bromure. Users can enable curated extensions (uBlock Origin Lite, Privacy Badger) with one-click toggles, or add custom extensions via Chrome Web Store URL. Extensions are installed via Chrome's `ExtensionSettings` enterprise policy with `force_installed` mode — Chrome handles its own download, installation, and DNR rule compilation.

- **Enable Extensions toggle**: Master switch in profile settings that gates extensions behind disabling Native Tabs. Chrome's built-in toolbar is required for extension icons and popup interaction. When toggled ON with Native Tabs active, a confirmation alert prompts the user to disable Native Tabs.
- **Curated extensions**: Two vetted privacy/security extensions (uBlock Origin Lite, Privacy Badger) with toggle switches. First enable triggers a host-side CRX download for metadata extraction.
- **Custom extensions**: Collapsible section with security warning banner. Users paste a Chrome Web Store URL or bare 32-char extension ID. CRX is downloaded to extract the display name from the manifest.
- **Host-side CRX cache**: `ExtensionCache` actor downloads CRX files from Google's update endpoint, caches them at `~/Library/Application Support/Bromure/extensions/<id>/`, and extracts names from `manifest.json` for the settings UI.
- **Guest-side Chrome policy**: `config-agent.py` writes `ExtensionSettings` policy with `force_installed` + `toolbar_pin: force_pinned` for each enabled extension. `--disable-extensions-except` is bypassed when user extensions are configured so policy-installed extensions can load.
- **Native Tabs interlock**: Native Tabs toggle is disabled with an explanation while extensions are active. Extensions require Chrome's toolbar for icon display and popup interaction.
- **Security hardening**: Extension IDs validated at three trust boundaries (host download, VMPool serialization, guest policy generation) — must match `[a-p]{32}`. CRX manifest extraction uses `-j` flag to prevent zip path traversal.
- **Backward compatible**: All new fields use `decodeIfPresent` with defaults — existing profiles decode cleanly.

## Data model changes

- `UserExtension` struct: `name`, `extensionID`, `enabled`, `curated` fields with `Codable`/`Equatable`/`Identifiable`
- `extensionsEnabled: Bool` on `ProfileSettings` (stored, default `false`)
- `userExtensions: [UserExtension]` on `ProfileSettings`
- `userExtensionIDs: [String]` on `VMConfig`, mapped from enabled extensions only when `extensionsEnabled` is true
- `CuratedExtensions.all` static list of 2 vetted extensions

## New files

| File | Purpose |
|------|---------|
| `Sources/SandboxEngine/CuratedExtensions.swift` | Static list of 2 curated security extensions |
| `Sources/SandboxEngine/ExtensionCache.swift` | Host-side CRX download, caching, ID validation, and manifest name extraction |

## Modified files

| File | Change |
|------|--------|
| `Sources/SandboxEngine/Profile.swift` | `UserExtension` struct, `extensionsEnabled` + `userExtensions` fields, Codable support, `toVMConfig()` mapping |
| `Sources/SandboxEngine/VMConfig.swift` | `userExtensionIDs` property |
| `Sources/SandboxEngine/VMPool.swift` | Pass validated `userExtensionIDs` in config JSON to guest |
| `Sources/SandboxEngine/Resources/vm-setup/scripts/config-agent.py` | `ExtensionSettings` Chrome policy with ID validation, bypass `--disable-extensions-except` for user extensions, `ExtensionsToolbarAccessEnabled` |
| `Sources/Browser/ProfileSettingsView.swift` | Extensions settings tab with Enable toggle, Native Tabs interlock alert, curated toggles, custom URL entry with security warning |
| `Tests/SafariSandboxTests/SafariSandboxTests.swift` | 10 tests across 3 suites |

## Security scan

Opengrep SAST scan (v1.20.0, 292 rules) on all 8 changed files:

```
0 new findings (4 pre-existing in config-agent.py: shell=True usage, chmod 0o755)
```

## Deployment note

The VM base image must be rebuilt (`bromure init`) after merging — `config-agent.py` changes are baked into the guest image.

## Test plan

- [x] `swift build` — zero errors
- [x] `swift test --skip E2E` — all extension tests pass (10/10, red-green validated)
- [x] `opengrep --config auto` — 0 new findings on all changed files
- [x] Manual: Extensions tab shows "Enable Extensions" toggle (OFF by default)
- [x] Manual: Toggle ON with Native Tabs active — confirmation alert appears, Native Tabs disabled on confirm
- [x] Manual: Curated extension toggles appear after enabling, individual enable/disable works
- [x] Manual: Custom extension via Chrome Web Store URL — name extracted from CRX manifest
- [x] Manual: Open session with extensions — Chrome toolbar shows extension icons, popups work natively
- [x] Manual: Native Tabs toggle disabled with explanation while extensions are active
- [x] Manual: Extensions persist across sessions with `persistent: true` profile
- [x] Manual: Backward compatibility — existing profiles without extension fields load cleanly
- [x] Manual: Invalid extension IDs rejected at host download, VMPool, and guest policy boundaries